### PR TITLE
Update Teads SDK to 2.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+v2.5.6
+- bug fix and improvements
+
 v2.5.5
 - bug fix and improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+v2.5.7
+- Disable tracking recovery by default to prevent issue on Android 8.x
+
 v2.5.6
 - bug fix and improvements
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ repositories{
     }
 }
 dependencies {
-    compile ('tv.teads.sdk:androidsdk:2.5.6:fullRelease@aar') {
+    compile ('tv.teads.sdk:androidsdk:2.5.7:fullRelease@aar') {
         transitive = true;
     }
 }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ repositories{
     }
 }
 dependencies {
-    compile ('tv.teads.sdk:androidsdk:2.5.5:fullRelease@aar') {
+    compile ('tv.teads.sdk:androidsdk:2.5.6:fullRelease@aar') {
         transitive = true;
     }
 }

--- a/TeadsSDKDemo/app/build.gradle
+++ b/TeadsSDKDemo/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "tv.teads.teadssdkdemo"
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 103
-        versionName "2.5.6"
+        versionCode 104
+        versionName "2.5.7"
         archivesBaseName = "teads-sdkdemo-" + versionName + sufixBaseName
     }
     buildTypes {
@@ -52,7 +52,7 @@ dependencies {
     compile 'org.greenrobot:eventbus:3.0.0'
 
     // Teads SDK
-    compile('tv.teads.sdk:androidsdk:2.5.6:fullRelease@aar') {
+    compile('tv.teads.sdk:androidsdk:2.5.7:fullRelease@aar') {
         transitive = true
     }
 }

--- a/TeadsSDKDemo/app/build.gradle
+++ b/TeadsSDKDemo/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "tv.teads.teadssdkdemo"
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 102
-        versionName "2.5.5"
+        versionCode 103
+        versionName "2.5.6"
         archivesBaseName = "teads-sdkdemo-" + versionName + sufixBaseName
     }
     buildTypes {
@@ -52,7 +52,7 @@ dependencies {
     compile 'org.greenrobot:eventbus:3.0.0'
 
     // Teads SDK
-    compile('tv.teads.sdk:androidsdk:2.5.5:fullRelease@aar') {
+    compile('tv.teads.sdk:androidsdk:2.5.6:fullRelease@aar') {
         transitive = true
     }
 }


### PR DESCRIPTION
- Disable tracking recovery by default to prevent issue on Android 8.x