### PR TITLE
v2.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+v2.5.6
+- bug fix and improvements
+
 v2.5.5
 - bug fix and improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+v2.5.9
+- Add support for brandsafety. If you have news content in your app, you should use `teadsConfiguration.pageUrl = "https://news.com/myArticle";` where the url is you equivalent http url of your article. More information [here](https://mobile.teads.tv/sdk/documentation/android/integration/inread/scrollview#brand-safety). 
+
 v2.5.8
 - Remove event service to prevent issue on Android 8.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+v2.5.7
+- Disable tracking recovery by default to prevent issue on Android 8.x
+
 v2.5.6
 - bug fix and improvements
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ repositories{
     }
 }
 dependencies {
-    compile ('tv.teads.sdk:androidsdk:2.5.6:fullRelease@aar') {
+    compile ('tv.teads.sdk:androidsdk:2.5.7:fullRelease@aar') {
         transitive = true;
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TeadsSDK-android         [![Build Status](https://jenkins.teadstesting.tv/buildStatus/icon?job=TeadsSDK-android_master)](https://jenkins.teadstesting.tv/job/TeadsSDK-android_master)  
+# TeadsSDK-android
 
 
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ repositories{
     }
 }
 dependencies {
-    compile ('tv.teads.sdk:androidsdk:2.5.8:fullRelease@aar') {
+    compile ('tv.teads.sdk:androidsdk:2.5.9:fullRelease@aar') {
         transitive = true;
     }
 }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ repositories{
     }
 }
 dependencies {
-    compile ('tv.teads.sdk:androidsdk:2.5.5:fullRelease@aar') {
+    compile ('tv.teads.sdk:androidsdk:2.5.6:fullRelease@aar') {
         transitive = true;
     }
 }

--- a/TeadsSDKDemo/app/build.gradle
+++ b/TeadsSDKDemo/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "24.0.3"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.1"
 
     String sufixBaseName = ""
 

--- a/TeadsSDKDemo/app/build.gradle
+++ b/TeadsSDKDemo/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "tv.teads.teadssdkdemo"
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 103
-        versionName "2.5.6"
+        versionCode 104
+        versionName "2.5.7"
         archivesBaseName = "teads-sdkdemo-" + versionName + sufixBaseName
     }
     buildTypes {
@@ -52,7 +52,7 @@ dependencies {
     compile 'org.greenrobot:eventbus:3.0.0'
 
     // Teads SDK
-    compile('tv.teads.sdk:androidsdk:2.5.6:fullRelease@aar') {
+    compile('tv.teads.sdk:androidsdk:2.5.7:fullRelease@aar') {
         transitive = true
     }
 }

--- a/TeadsSDKDemo/app/build.gradle
+++ b/TeadsSDKDemo/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "tv.teads.teadssdkdemo"
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 105
-        versionName "2.5.8"
+        versionCode 106
+        versionName "2.5.9"
         archivesBaseName = "teads-sdkdemo-" + versionName + sufixBaseName
     }
     buildTypes {
@@ -52,7 +52,7 @@ dependencies {
     compile 'org.greenrobot:eventbus:3.0.0'
 
     // Teads SDK
-    compile('tv.teads.sdk:androidsdk:2.5.8:fullRelease@aar') {
+    compile('tv.teads.sdk:androidsdk:2.5.9:fullRelease@aar') {
         transitive = true
     }
 }

--- a/TeadsSDKDemo/app/build.gradle
+++ b/TeadsSDKDemo/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "tv.teads.teadssdkdemo"
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 102
-        versionName "2.5.5"
+        versionCode 103
+        versionName "2.5.6"
         archivesBaseName = "teads-sdkdemo-" + versionName + sufixBaseName
     }
     buildTypes {
@@ -52,7 +52,7 @@ dependencies {
     compile 'org.greenrobot:eventbus:3.0.0'
 
     // Teads SDK
-    compile('tv.teads.sdk:androidsdk:2.5.5:fullRelease@aar') {
+    compile('tv.teads.sdk:androidsdk:2.5.6:fullRelease@aar') {
         transitive = true
     }
 }


### PR DESCRIPTION
v2.5.9
- Add support for brandsafety. If you have an http url of your content you can provide it with `teadsConfiguration.pageUrl = "https://example.com/myArticle";`. More information [here](https://mobile.teads.tv/sdk/documentation/android/integration/inread/scrollview#brand-safety). 