### PR TITLE
Change deprecated interfaces

### DIFF
--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/InReadWebViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/InReadWebViewFragment.kt
@@ -72,13 +72,13 @@ class InReadWebViewFragment : BaseFragment(), SyncAdWebView.Listener {
                 .build()
 
         // 3. Request the ad and register to the listener in it
-        adPlacement.requestAd(requestSettings, object : InReadAdListener {
+        adPlacement.requestAd(requestSettings, object : InReadAdViewListener {
             override fun adOpportunityTrackerView(trackerView: AdOpportunityTrackerView) {
                 webviewHelperSynch.registerTrackerView(trackerView)
             }
 
-            override fun onAdReceived(inReadAdView: InReadAdView, adRatio: AdRatio) {
-                webviewHelperSynch.registerAdView(inReadAdView)
+            override fun onAdReceived(ad: InReadAdView, adRatio: AdRatio) {
+                webviewHelperSynch.registerAdView(ad)
                 webviewHelperSynch.updateSlot(adRatio.getAdSlotRatio(webview.measuredWidth))
             }
 

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/adapter/SimpleRecyclerViewAdapter.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/adapter/SimpleRecyclerViewAdapter.kt
@@ -43,13 +43,13 @@ class SimpleRecyclerViewAdapter(private val context: Context?, pid: Int, title: 
             RecyclerItemType.TYPE_TEADS.value -> {
                 val adView = holder.itemView as FrameLayout
                 // 3. Request the ad and register to the listener in it
-                adPlacement.requestAd(requestSettings, object : InReadAdListener {
+                adPlacement.requestAd(requestSettings, object : InReadAdViewListener {
                     override fun adOpportunityTrackerView(trackerView: AdOpportunityTrackerView) {
                         adView.addView(trackerView)
                     }
 
-                    override fun onAdReceived(inReadAdView: InReadAdView, adRatio: AdRatio) {
-                        adView.addView(inReadAdView, 0)
+                    override fun onAdReceived(ad: InReadAdView, adRatio: AdRatio) {
+                        adView.addView(ad, 0)
                     }
 
                     override fun onAdClicked() {}


### PR DESCRIPTION
Turn pubs life easier by not providing them deprecated usage in the sample app.