### PR TITLE
Layout params fix

### DIFF
--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/component/GenericRecyclerViewAdapter.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/component/GenericRecyclerViewAdapter.kt
@@ -15,7 +15,7 @@ open class GenericRecyclerViewAdapter(private val mTitle: String) : RecyclerView
             0 -> RecyclerItemType.TYPE_SCROLL_DOWN.value
             1 -> RecyclerItemType.TYPE_ARTICLE_TITLE.value
             2 -> RecyclerItemType.TYPE_ARTICLE_REAL_LINES.value
-            6 -> RecyclerItemType.TYPE_TEADS.value
+            4 -> RecyclerItemType.TYPE_TEADS.value
             else -> RecyclerItemType.TYPE_ARTICLE_FAKE_LINES.value
         }
     }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/headerbidding/prebid/PluginRendererScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/headerbidding/prebid/PluginRendererScrollViewFragment.kt
@@ -20,6 +20,7 @@ import tv.teads.sdk.TeadsMediationSettings
 import tv.teads.teadssdkdemo.R
 import tv.teads.teadssdkdemo.data.CreativeSize
 import tv.teads.teadssdkdemo.databinding.FragmentInreadScrollviewBinding
+import tv.teads.teadssdkdemo.format.inread.extensions.resizeAdContainer
 import tv.teads.teadssdkdemo.format.mediation.identifier.PrebidIdentifier
 import tv.teads.teadssdkdemo.utils.BaseFragment
 
@@ -67,14 +68,10 @@ class PluginRendererScrollViewFragment : BaseFragment() {
 
         // 6 . Listen TeadsPBMEventListener events and manage onAdRatioUpdate to have your view correctly displayed
         bannerView?.setPluginEventListener(object : TeadsPBMEventListener{
-            override fun onAdRatioUpdate(adRatio: AdRatio) { // todo update logic
+            override fun onAdRatioUpdate(adRatio: AdRatio) {
                 Log.d("TeadsPBMEventListener", "onAdRatioUpdate")
-
-                bannerView?.let {
-                    val adViewParams = binding.adSlotContainer.layoutParams
-                    adViewParams.height = adRatio.calculateHeight(it.measuredWidth)
-                    binding.adSlotContainer.layoutParams = adViewParams
-                }
+                // Resize
+                binding.adSlotContainer.resizeAdContainer(adRatio)
             }
 
             override fun onAdCollapsedFromFullscreen() {

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/headerbidding/prebid/PluginRendererScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/headerbidding/prebid/PluginRendererScrollViewFragment.kt
@@ -67,13 +67,13 @@ class PluginRendererScrollViewFragment : BaseFragment() {
 
         // 6 . Listen TeadsPBMEventListener events and manage onAdRatioUpdate to have your view correctly displayed
         bannerView?.setPluginEventListener(object : TeadsPBMEventListener{
-            override fun onAdRatioUpdate(adRatio: AdRatio) {
+            override fun onAdRatioUpdate(adRatio: AdRatio) { // todo update logic
                 Log.d("TeadsPBMEventListener", "onAdRatioUpdate")
 
                 bannerView?.let {
-                    val adViewParams = binding.adSlotView.layoutParams
+                    val adViewParams = binding.adSlotContainer.layoutParams
                     adViewParams.height = adRatio.calculateHeight(it.measuredWidth)
-                    binding.adSlotView.layoutParams = adViewParams
+                    binding.adSlotContainer.layoutParams = adViewParams
                 }
             }
 
@@ -114,7 +114,7 @@ class PluginRendererScrollViewFragment : BaseFragment() {
         })
 
         // 8. Add the ad view to its container
-        bannerView?.let { binding.adSlotView.addView(it) }
+        bannerView?.let { binding.adSlotContainer.addView(it) }
 
         // 9. Load the ad
         bannerView?.loadAd()

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/headerbidding/prebid/StandaloneIntegrationScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/headerbidding/prebid/StandaloneIntegrationScrollViewFragment.kt
@@ -61,24 +61,24 @@ class StandaloneIntegrationScrollViewFragment : BaseFragment() {
             FAKE_WINNING_BID_RESPONSE,
             requestSettings,
             object : InReadAdViewListener {
-                override fun onAdReceived(ad: InReadAdView, adRatio: AdRatio) {
+                override fun onAdReceived(ad: InReadAdView, adRatio: AdRatio) { // todo update logic
                     val layoutParams = ad.layoutParams
-                    binding.adSlotView.addView(ad)
-                    layoutParams.height = adRatio.calculateHeight(binding.adSlotView.measuredWidth)
-                    binding.adSlotView.layoutParams = layoutParams
+                    binding.adSlotContainer.addView(ad)
+                    layoutParams.height = adRatio.calculateHeight(binding.adSlotContainer.measuredWidth)
+                    binding.adSlotContainer.layoutParams = layoutParams
 
                     inReadAdView = ad
                 }
 
                 override fun adOpportunityTrackerView(trackerView: AdOpportunityTrackerView) {
-                    binding.adSlotView.addView(trackerView)
+                    binding.adSlotContainer.addView(trackerView)
                 }
 
-                override fun onAdRatioUpdate(adRatio: AdRatio) {
+                override fun onAdRatioUpdate(adRatio: AdRatio) { // todo update logic
                     inReadAdView?.let { inReadAdView ->
                         val layoutParams = inReadAdView.layoutParams
-                        layoutParams.height = adRatio.calculateHeight(binding.adSlotView.measuredWidth)
-                        binding.adSlotView.layoutParams = layoutParams
+                        layoutParams.height = adRatio.calculateHeight(binding.adSlotContainer.measuredWidth)
+                        binding.adSlotContainer.layoutParams = layoutParams
                     }
                 }
 

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/headerbidding/prebid/StandaloneIntegrationScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/headerbidding/prebid/StandaloneIntegrationScrollViewFragment.kt
@@ -18,6 +18,7 @@ import tv.teads.sdk.VideoPlaybackListener
 import tv.teads.sdk.renderer.InReadAdView
 import tv.teads.teadssdkdemo.R
 import tv.teads.teadssdkdemo.databinding.FragmentInreadScrollviewBinding
+import tv.teads.teadssdkdemo.format.inread.extensions.resizeAdContainer
 import tv.teads.teadssdkdemo.utils.BaseFragment
 
 /**
@@ -61,25 +62,22 @@ class StandaloneIntegrationScrollViewFragment : BaseFragment() {
             FAKE_WINNING_BID_RESPONSE,
             requestSettings,
             object : InReadAdViewListener {
-                override fun onAdReceived(ad: InReadAdView, adRatio: AdRatio) { // todo update logic
-                    val layoutParams = ad.layoutParams
-                    binding.adSlotContainer.addView(ad)
-                    layoutParams.height = adRatio.calculateHeight(binding.adSlotContainer.measuredWidth)
-                    binding.adSlotContainer.layoutParams = layoutParams
-
+                override fun onAdReceived(ad: InReadAdView, adRatio: AdRatio) {
+                    // Clean and init inReadAdView
+                    inReadAdView?.clean()
                     inReadAdView = ad
+                    // Add ad to the container and resize
+                    binding.adSlotContainer.addView(ad)
+                    binding.adSlotContainer.resizeAdContainer(adRatio)
                 }
 
                 override fun adOpportunityTrackerView(trackerView: AdOpportunityTrackerView) {
                     binding.adSlotContainer.addView(trackerView)
                 }
 
-                override fun onAdRatioUpdate(adRatio: AdRatio) { // todo update logic
-                    inReadAdView?.let { inReadAdView ->
-                        val layoutParams = inReadAdView.layoutParams
-                        layoutParams.height = adRatio.calculateHeight(binding.adSlotContainer.measuredWidth)
-                        binding.adSlotContainer.layoutParams = layoutParams
-                    }
+                override fun onAdRatioUpdate(adRatio: AdRatio) {
+                    // Resize
+                    binding.adSlotContainer.resizeAdContainer(adRatio)
                 }
 
                 override fun onAdClicked() {}

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/InReadGridRecyclerViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/InReadGridRecyclerViewFragment.kt
@@ -9,7 +9,11 @@ import androidx.recyclerview.widget.RecyclerView
 import tv.teads.teadssdkdemo.databinding.FragmentRecyclerviewBinding
 import tv.teads.teadssdkdemo.format.inread.adapter.SimpleRecyclerViewAdapter
 import tv.teads.teadssdkdemo.utils.BaseFragment
-
+/**
+ *
+ * inRead format within a RecyclerView
+ *
+ */
 class InReadGridRecyclerViewFragment : BaseFragment() {
     private lateinit var binding: FragmentRecyclerviewBinding
     private lateinit var adapter: SimpleRecyclerViewAdapter

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/InReadScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/InReadScrollViewFragment.kt
@@ -42,66 +42,59 @@ class InReadScrollViewFragment : BaseFragment() {
 
         // 1. Setup the settings
         val placementSettings = AdPlacementSettings.Builder()
-                .enableDebug()
-                .build()
+            .enableDebug()
+            .build()
 
         // 2. Create the InReadAdPlacement
         adPlacement = TeadsSDK.createInReadPlacement(requireActivity(), pid, placementSettings)
 
         // 3. Request the ad and listen its events
         val requestSettings = AdRequestSettings.Builder()
-                .pageSlotUrl("http://teads.com")
-                .build()
+            .pageSlotUrl("http://teads.com")
+            .build()
         adPlacement.requestAd(requestSettings,
-                object : InReadAdViewListener {
-                    override fun onAdReceived(ad: InReadAdView, adRatio: AdRatio) {
-                        // Clean and init inReadAdView
-                        inReadAdView?.clean()
-                        inReadAdView = ad
-                        // Add ad to the container and resize
-                        binding.adSlotContainer.addView(ad)
-                        binding.adSlotContainer.resizeAdContainer {
-                            adRatio.calculateHeight(binding.adSlotContainer.measuredWidth)
-                        }
-                    }
-
-                    override fun adOpportunityTrackerView(trackerView: AdOpportunityTrackerView) {
-                        // Resize ad container
-                        binding.adSlotContainer.addView(trackerView)
-                    }
-
-                    override fun onAdRatioUpdate(adRatio: AdRatio) {
-                        // Resize the ad container
-                        inReadAdView?.let { adView ->
-                            binding.adSlotContainer.resizeAdContainer {
-                                adRatio.calculateHeight(adView.measuredWidth)
-                            }
-
-                        }
-                    }
-
-                    override fun onAdClicked() {}
-                    override fun onAdClosed() {}
-                    override fun onAdError(code: Int, description: String) {}
-                    override fun onAdImpression() {}
-                    override fun onAdExpandedToFullscreen() {}
-                    override fun onAdCollapsedFromFullscreen() {}
-                    override fun onFailToReceiveAd(failReason: String) {}
-                },
-                object : VideoPlaybackListener {
-                    override fun onVideoComplete() {
-                        Log.d("PlaybackEvent", "complete")
-                    }
-
-                    override fun onVideoPause() {
-                        Log.d("PlaybackEvent", "pause")
-                    }
-
-                    override fun onVideoPlay() {
-                        Log.d("PlaybackEvent", "play")
-                    }
-
+            object : InReadAdViewListener {
+                override fun onAdReceived(ad: InReadAdView, adRatio: AdRatio) {
+                    // Clean and init inReadAdView
+                    inReadAdView?.clean()
+                    inReadAdView = ad
+                    // Add ad to the container and resize
+                    binding.adSlotContainer.addView(ad)
+                    binding.adSlotContainer.resizeAdContainer(adRatio)
                 }
+
+                override fun adOpportunityTrackerView(trackerView: AdOpportunityTrackerView) {
+                    // Resize ad container
+                    binding.adSlotContainer.addView(trackerView)
+                }
+
+                override fun onAdRatioUpdate(adRatio: AdRatio) {
+                    // Resize the ad container
+                    binding.adSlotContainer.resizeAdContainer(adRatio)
+                }
+
+                override fun onAdClicked() {}
+                override fun onAdClosed() {}
+                override fun onAdError(code: Int, description: String) {}
+                override fun onAdImpression() {}
+                override fun onAdExpandedToFullscreen() {}
+                override fun onAdCollapsedFromFullscreen() {}
+                override fun onFailToReceiveAd(failReason: String) {}
+            },
+            object : VideoPlaybackListener {
+                override fun onVideoComplete() {
+                    Log.d("PlaybackEvent", "complete")
+                }
+
+                override fun onVideoPause() {
+                    Log.d("PlaybackEvent", "pause")
+                }
+
+                override fun onVideoPlay() {
+                    Log.d("PlaybackEvent", "play")
+                }
+
+            }
         )
     }
 

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/InReadScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/InReadScrollViewFragment.kt
@@ -58,9 +58,11 @@ class InReadScrollViewFragment : BaseFragment() {
                         // Clean and init inReadAdView
                         inReadAdView?.clean()
                         inReadAdView = ad
-                        // Add add to the container and resize
+                        // Add ad to the container and resize
                         binding.adSlotContainer.addView(ad)
-                        binding.adSlotContainer.resizeAdContainer(adRatio)
+                        binding.adSlotContainer.resizeAdContainer {
+                            adRatio.calculateHeight(binding.adSlotContainer.measuredWidth)
+                        }
                     }
 
                     override fun adOpportunityTrackerView(trackerView: AdOpportunityTrackerView) {
@@ -70,7 +72,12 @@ class InReadScrollViewFragment : BaseFragment() {
 
                     override fun onAdRatioUpdate(adRatio: AdRatio) {
                         // Resize the ad container
-                        binding.adSlotContainer.resizeAdContainer(adRatio)
+                        inReadAdView?.let { adView ->
+                            binding.adSlotContainer.resizeAdContainer {
+                                adRatio.calculateHeight(adView.measuredWidth)
+                            }
+
+                        }
                     }
 
                     override fun onAdClicked() {}

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/InReadScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/InReadScrollViewFragment.kt
@@ -17,6 +17,7 @@ import tv.teads.sdk.VideoPlaybackListener
 import tv.teads.sdk.renderer.InReadAdView
 import tv.teads.teadssdkdemo.R
 import tv.teads.teadssdkdemo.databinding.FragmentInreadScrollviewBinding
+import tv.teads.teadssdkdemo.format.inread.extensions.resizeAdContainer
 import tv.teads.teadssdkdemo.utils.BaseFragment
 
 /**
@@ -54,24 +55,22 @@ class InReadScrollViewFragment : BaseFragment() {
         adPlacement.requestAd(requestSettings,
                 object : InReadAdViewListener {
                     override fun onAdReceived(ad: InReadAdView, adRatio: AdRatio) {
-                        val layoutParams = ad.layoutParams
-                        binding.adSlotView.addView(ad)
-                        layoutParams.height = adRatio.calculateHeight(binding.adSlotView.measuredWidth)
-                        binding.adSlotView.layoutParams = layoutParams
-
+                        // Clean and init inReadAdView
+                        inReadAdView?.clean()
                         inReadAdView = ad
+                        // Add add to the container and resize
+                        binding.adSlotContainer.addView(ad)
+                        binding.adSlotContainer.resizeAdContainer(adRatio)
                     }
 
                     override fun adOpportunityTrackerView(trackerView: AdOpportunityTrackerView) {
-                        binding.adSlotView.addView(trackerView)
+                        // Resize ad container
+                        binding.adSlotContainer.addView(trackerView)
                     }
 
                     override fun onAdRatioUpdate(adRatio: AdRatio) {
-                        inReadAdView?.let { inReadAdView ->
-                            val layoutParams = inReadAdView.layoutParams
-                            layoutParams.height = adRatio.calculateHeight(binding.adSlotView.measuredWidth)
-                            binding.adSlotView.layoutParams = layoutParams
-                        }
+                        // Resize the ad container
+                        binding.adSlotContainer.resizeAdContainer(adRatio)
                     }
 
                     override fun onAdClicked() {}

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/adapter/SimpleRecyclerViewAdapter.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/adapter/SimpleRecyclerViewAdapter.kt
@@ -8,6 +8,7 @@ import tv.teads.sdk.*
 import tv.teads.sdk.renderer.InReadAdView
 import tv.teads.teadssdkdemo.component.GenericRecyclerViewAdapter
 import tv.teads.teadssdkdemo.data.RecyclerItemType
+import tv.teads.teadssdkdemo.format.inread.extensions.resizeAdContainer
 
 /**
  * Simple RecyclerView adapter
@@ -41,30 +42,27 @@ class SimpleRecyclerViewAdapter(private val context: Context?, pid: Int, title: 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder.itemViewType) {
             RecyclerItemType.TYPE_TEADS.value -> {
-                val adViewContainer = holder.itemView as FrameLayout
+                val adSlotContainer = holder.itemView as FrameLayout
                 var inReadAdView: InReadAdView? = null
 
                 // 3. Request the ad and register to the listener in it
                 adPlacement.requestAd(requestSettings, object : InReadAdViewListener {
                     override fun adOpportunityTrackerView(trackerView: AdOpportunityTrackerView) {
-                        adViewContainer.addView(trackerView)
+                        adSlotContainer.addView(trackerView)
                     }
 
                     override fun onAdReceived(ad: InReadAdView, adRatio: AdRatio) {
-                        val layoutParams = ad.layoutParams
-                        adViewContainer.addView(ad, 0)
-                        layoutParams.height = adRatio.calculateHeight(adViewContainer.measuredWidth)
-                        adViewContainer.layoutParams = layoutParams
-
+                        // Clean and init inReadAdView
+                        inReadAdView?.clean()
                         inReadAdView = ad
+                        // Add add to the container and resize
+                        adSlotContainer.addView(ad, 0)
+                        adSlotContainer.resizeAdContainer(adRatio)
                     }
 
                     override fun onAdRatioUpdate(adRatio: AdRatio) {
-                        inReadAdView?.let { inReadAdView ->
-                            val layoutParams = inReadAdView.layoutParams
-                            layoutParams.height = adRatio.calculateHeight(adViewContainer.measuredWidth)
-                            adViewContainer.layoutParams = layoutParams
-                        }
+                        // Resize ad container
+                        adSlotContainer.resizeAdContainer(adRatio)
                     }
 
                     override fun onAdClicked() {}

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/adapter/SimpleRecyclerViewAdapter.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/adapter/SimpleRecyclerViewAdapter.kt
@@ -53,16 +53,21 @@ class SimpleRecyclerViewAdapter(private val context: Context?, pid: Int, title: 
 
                     override fun onAdReceived(ad: InReadAdView, adRatio: AdRatio) {
                         // Clean and init inReadAdView
-                        inReadAdView?.clean()
                         inReadAdView = ad
-                        // Add add to the container and resize
+                        // Add ad to the container and resize
                         adSlotContainer.addView(ad, 0)
-                        adSlotContainer.resizeAdContainer(adRatio)
+                        adSlotContainer.resizeAdContainer {
+                            adRatio.calculateHeight(adSlotContainer.measuredWidth)
+                        }
                     }
 
                     override fun onAdRatioUpdate(adRatio: AdRatio) {
-                        // Resize ad container
-                        adSlotContainer.resizeAdContainer(adRatio)
+                        // Resize
+                        inReadAdView?.let { adView ->
+                            adSlotContainer.resizeAdContainer {
+                                adRatio.calculateHeight(adView.measuredWidth)
+                            }
+                        }
                     }
 
                     override fun onAdClicked() {}

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/adapter/SimpleRecyclerViewAdapter.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/adapter/SimpleRecyclerViewAdapter.kt
@@ -43,6 +43,7 @@ class SimpleRecyclerViewAdapter(private val context: Context?, pid: Int, title: 
         when (holder.itemViewType) {
             RecyclerItemType.TYPE_TEADS.value -> {
                 val adSlotContainer = holder.itemView as FrameLayout
+                adSlotContainer.layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
                 var inReadAdView: InReadAdView? = null
 
                 // 3. Request the ad and register to the listener in it
@@ -55,19 +56,13 @@ class SimpleRecyclerViewAdapter(private val context: Context?, pid: Int, title: 
                         // Clean and init inReadAdView
                         inReadAdView = ad
                         // Add ad to the container and resize
+                        adSlotContainer.resizeAdContainer(adRatio)
                         adSlotContainer.addView(ad, 0)
-                        adSlotContainer.resizeAdContainer {
-                            adRatio.calculateHeight(adSlotContainer.measuredWidth)
-                        }
                     }
 
                     override fun onAdRatioUpdate(adRatio: AdRatio) {
                         // Resize
-                        inReadAdView?.let { adView ->
-                            adSlotContainer.resizeAdContainer {
-                                adRatio.calculateHeight(adView.measuredWidth)
-                            }
-                        }
+                        adSlotContainer.resizeAdContainer(adRatio)
                     }
 
                     override fun onAdClicked() {}

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/adapter/SimpleRecyclerViewAdapter.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/adapter/SimpleRecyclerViewAdapter.kt
@@ -44,7 +44,6 @@ class SimpleRecyclerViewAdapter(private val context: Context?, pid: Int, title: 
             RecyclerItemType.TYPE_TEADS.value -> {
                 val adSlotContainer = holder.itemView as FrameLayout
                 adSlotContainer.layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-                var inReadAdView: InReadAdView? = null
 
                 // 3. Request the ad and register to the listener in it
                 adPlacement.requestAd(requestSettings, object : InReadAdViewListener {
@@ -53,8 +52,6 @@ class SimpleRecyclerViewAdapter(private val context: Context?, pid: Int, title: 
                     }
 
                     override fun onAdReceived(ad: InReadAdView, adRatio: AdRatio) {
-                        // Clean and init inReadAdView
-                        inReadAdView = ad
                         // Add ad to the container and resize
                         adSlotContainer.resizeAdContainer(adRatio)
                         adSlotContainer.addView(ad, 0)

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/extensions/ViewExtensions.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/extensions/ViewExtensions.kt
@@ -1,0 +1,11 @@
+package tv.teads.teadssdkdemo.format.inread.extensions
+
+import android.view.View
+import tv.teads.sdk.AdRatio
+
+fun View.resizeAdContainer(adRatio: AdRatio) {
+    val adSlotContainer = this
+    val adSlotContainerParams = adSlotContainer.layoutParams
+    adSlotContainerParams.height = adRatio.calculateHeight(adSlotContainer.measuredWidth)
+    adSlotContainer.layoutParams = adSlotContainerParams
+}

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/extensions/ViewExtensions.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/extensions/ViewExtensions.kt
@@ -3,6 +3,13 @@ package tv.teads.teadssdkdemo.format.inread.extensions
 import android.view.View
 import tv.teads.sdk.AdRatio
 
+/**
+ * Resize the ad container to the correct height
+ * @param adRatio the ratio of the ad
+ *
+ * adRatio.calculateHeight(adSlotContainer.measuredWidth) calculates the height of the ad container
+ * measuredWidth parameter must to be from the ad container/view group encapsulating the ad view
+ */
 fun View.resizeAdContainer(adRatio: AdRatio) {
     val adSlotContainer = this
     val adSlotContainerParams = adSlotContainer.layoutParams

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/extensions/ViewExtensions.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/extensions/ViewExtensions.kt
@@ -3,9 +3,9 @@ package tv.teads.teadssdkdemo.format.inread.extensions
 import android.view.View
 import tv.teads.sdk.AdRatio
 
-fun View.resizeAdContainer(onCalculateHeight: () -> Int) {
+fun View.resizeAdContainer(adRatio: AdRatio) {
     val adSlotContainer = this
     val adSlotContainerParams = adSlotContainer.layoutParams
-    adSlotContainerParams.height = onCalculateHeight()
+    adSlotContainerParams.height = adRatio.calculateHeight(adSlotContainer.measuredWidth)
     adSlotContainer.layoutParams = adSlotContainerParams
 }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/extensions/ViewExtensions.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/inread/extensions/ViewExtensions.kt
@@ -3,9 +3,9 @@ package tv.teads.teadssdkdemo.format.inread.extensions
 import android.view.View
 import tv.teads.sdk.AdRatio
 
-fun View.resizeAdContainer(adRatio: AdRatio) {
+fun View.resizeAdContainer(onCalculateHeight: () -> Int) {
     val adSlotContainer = this
     val adSlotContainerParams = adSlotContainer.layoutParams
-    adSlotContainerParams.height = adRatio.calculateHeight(adSlotContainer.measuredWidth)
+    adSlotContainerParams.height = onCalculateHeight()
     adSlotContainer.layoutParams = adSlotContainerParams
 }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/adapter/AdMobRecyclerViewAdapter.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/adapter/AdMobRecyclerViewAdapter.kt
@@ -16,19 +16,20 @@ import tv.teads.sdk.utils.userConsent.TCFVersion
 import tv.teads.teadssdkdemo.component.GenericRecyclerViewAdapter
 import tv.teads.teadssdkdemo.data.RecyclerItemType
 import tv.teads.teadssdkdemo.data.SessionDataSource
+import tv.teads.teadssdkdemo.format.inread.extensions.resizeAdContainer
 
 /**
  * Simple RecyclerView adapter
  */
-class AdMobRecyclerViewAdapter(admobBannerId: String, context: Context?, title: String)
+class AdMobRecyclerViewAdapter(admobBannerId: String, context: Context, title: String)
     : GenericRecyclerViewAdapter(title) {
 
-    private val adView: AdView = AdView(context!!)
+    private val adView: AdView = AdView(context)
     private val mListener: TeadsAdapterListener
 
     init {
         // 1. Initialize AdMob & Teads Helper
-        MobileAds.initialize(context!!)
+        MobileAds.initialize(context)
         TeadsHelper.initialize()
 
         // 2. Setup the AdMob view
@@ -67,12 +68,7 @@ class AdMobRecyclerViewAdapter(admobBannerId: String, context: Context?, title: 
                 adView.viewTreeObserver.addOnGlobalLayoutListener(object : OnGlobalLayoutListener {
                     override fun onGlobalLayout() {
                         adView.viewTreeObserver.removeOnGlobalLayoutListener(this)
-                        val params: ViewGroup.LayoutParams = adView.layoutParams
-
-                        // Here the width is MATCH_PARENT
-                        params.height = adRatio.calculateHeight(adView.measuredWidth)
-
-                        adView.layoutParams = params
+                        adView.resizeAdContainer(adRatio)
                     }
                 })
             }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/adapter/AppLovinRecyclerViewAdapter.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/adapter/AppLovinRecyclerViewAdapter.kt
@@ -19,14 +19,15 @@ import tv.teads.sdk.utils.userConsent.TCFVersion
 import tv.teads.teadssdkdemo.component.GenericRecyclerViewAdapter
 import tv.teads.teadssdkdemo.data.RecyclerItemType
 import tv.teads.teadssdkdemo.data.SessionDataSource
+import tv.teads.teadssdkdemo.format.inread.extensions.resizeAdContainer
 
 /**
  * Simple RecyclerView adapter
  */
-class AppLovinRecyclerViewAdapter(appLovinUnitId: String, context: Context?, title: String)
+class AppLovinRecyclerViewAdapter(appLovinUnitId: String, context: Context, title: String)
     : GenericRecyclerViewAdapter(title) {
 
-    private val adView: MaxAdView = MaxAdView(appLovinUnitId, MaxAdFormat.MREC, context!!)
+    private val adView: MaxAdView = MaxAdView(appLovinUnitId, MaxAdFormat.MREC, context)
     private val mListener: TeadsAdapterListener
 
     init {
@@ -65,12 +66,7 @@ class AppLovinRecyclerViewAdapter(appLovinUnitId: String, context: Context?, tit
                 adView.viewTreeObserver.addOnGlobalLayoutListener(object : OnGlobalLayoutListener {
                     override fun onGlobalLayout() {
                         adView.viewTreeObserver.removeOnGlobalLayoutListener(this)
-                        val params: ViewGroup.LayoutParams = adView.layoutParams
-
-                        // Here the width is MATCH_PARENT
-                        params.height = adRatio.calculateHeight(adView.measuredWidth)
-
-                        adView.layoutParams = params
+                        adView.resizeAdContainer(adRatio)
                     }
                 })
             }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/admob/AdMobGridRecyclerViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/admob/AdMobGridRecyclerViewFragment.kt
@@ -12,7 +12,8 @@ import tv.teads.teadssdkdemo.format.mediation.identifier.AdMobIdentifier
 import tv.teads.teadssdkdemo.utils.BaseFragment
 
 /**
- * Display inRead as Banner within a RecyclerView using AdMob Mediation.
+ * inRead format within a RecyclerView
+ *
  */
 class AdMobGridRecyclerViewFragment : BaseFragment() {
     private lateinit var binding: FragmentRecyclerviewBinding
@@ -32,7 +33,7 @@ class AdMobGridRecyclerViewFragment : BaseFragment() {
 
         val adUnit = AdMobIdentifier.getAdUnitFromPid(pid)
 
-        recyclerView.adapter = AdMobRecyclerViewAdapter(adUnit, context, getTitle())
+        recyclerView.adapter = AdMobRecyclerViewAdapter(adUnit, requireContext(), getTitle())
     }
 
     override fun getTitle(): String = "InRead AdMob RecyclerView Grid"

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/admob/AdMobRecyclerViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/admob/AdMobRecyclerViewFragment.kt
@@ -12,7 +12,8 @@ import tv.teads.teadssdkdemo.format.mediation.identifier.AdMobIdentifier
 import tv.teads.teadssdkdemo.utils.BaseFragment
 
 /**
- * Display inRead as Banner within a RecyclerView using AdMob Mediation.
+ * inRead format within a RecyclerView
+ *
  */
 class AdMobRecyclerViewFragment : BaseFragment() {
     private lateinit var binding: FragmentRecyclerviewBinding
@@ -32,7 +33,7 @@ class AdMobRecyclerViewFragment : BaseFragment() {
 
         val adUnit = AdMobIdentifier.getAdUnitFromPid(pid)
 
-        recyclerView.adapter = AdMobRecyclerViewAdapter(adUnit, context, getTitle())
+        recyclerView.adapter = AdMobRecyclerViewAdapter(adUnit, requireContext(), getTitle())
     }
 
     override fun getTitle(): String = "InRead AdMob RecyclerView"

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/admob/AdMobScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/admob/AdMobScrollViewFragment.kt
@@ -17,6 +17,7 @@ import tv.teads.sdk.utils.userConsent.TCFVersion
 import tv.teads.teadssdkdemo.R
 import tv.teads.teadssdkdemo.data.SessionDataSource
 import tv.teads.teadssdkdemo.databinding.FragmentInreadScrollviewBinding
+import tv.teads.teadssdkdemo.format.inread.extensions.resizeAdContainer
 import tv.teads.teadssdkdemo.format.mediation.identifier.AdMobIdentifier
 import tv.teads.teadssdkdemo.utils.BaseFragment
 
@@ -63,12 +64,7 @@ class AdMobScrollViewFragment : BaseFragment() {
          */
         mListener = object : TeadsAdapterListener {
             override fun onRatioUpdated(adRatio: AdRatio) {
-                val params: ViewGroup.LayoutParams = adView.layoutParams
-
-                // Here the width is MATCH_PARENT
-                params.height = adRatio.calculateHeight(adView.measuredWidth)
-
-                adView.layoutParams = params
+                binding.adSlotContainer.resizeAdContainer(adRatio)
             }
 
             override fun adOpportunityTrackerView(trackerView: AdOpportunityTrackerView) {

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/admob/AdMobScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/admob/AdMobScrollViewFragment.kt
@@ -44,7 +44,7 @@ class AdMobScrollViewFragment : BaseFragment() {
         val adView = AdView(view.context)
         adView.adUnitId = AdMobIdentifier.getAdUnitFromPid(pid)
         adView.setAdSize(AdSize.MEDIUM_RECTANGLE)
-        binding.adSlotView.addView(adView, 0)
+        binding.adSlotContainer.addView(adView, 0)
 
         // 3. Attach listener (will include Teads events)
         adView.adListener = object : AdListener() {
@@ -72,7 +72,7 @@ class AdMobScrollViewFragment : BaseFragment() {
             }
 
             override fun adOpportunityTrackerView(trackerView: AdOpportunityTrackerView) {
-                binding.adSlotView.addView(trackerView)
+                binding.adSlotContainer.addView(trackerView)
             }
 
         }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/applovin/AppLovinGridRecyclerViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/applovin/AppLovinGridRecyclerViewFragment.kt
@@ -7,12 +7,13 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import tv.teads.teadssdkdemo.databinding.FragmentRecyclerviewBinding
-import tv.teads.teadssdkdemo.format.mediation.adapter.AdMobRecyclerViewAdapter
+import tv.teads.teadssdkdemo.format.mediation.adapter.AppLovinRecyclerViewAdapter
 import tv.teads.teadssdkdemo.format.mediation.identifier.AppLovinIdentifier
 import tv.teads.teadssdkdemo.utils.BaseFragment
 
 /**
- * Display inRead as Banner within a RecyclerView using AdMob Mediation.
+ * inRead format within a RecyclerView
+ *
  */
 class AppLovinGridRecyclerViewFragment : BaseFragment() {
     private lateinit var binding: FragmentRecyclerviewBinding
@@ -32,7 +33,7 @@ class AppLovinGridRecyclerViewFragment : BaseFragment() {
 
         val adUnit = AppLovinIdentifier.getAdUnitFromPid(pid)
 
-        recyclerView.adapter = AdMobRecyclerViewAdapter(adUnit, context, getTitle())
+        recyclerView.adapter = AppLovinRecyclerViewAdapter(adUnit, requireContext(), getTitle())
     }
 
     override fun getTitle(): String = "InRead AppLovin RecyclerView Grid"

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/applovin/AppLovinRecyclerViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/applovin/AppLovinRecyclerViewFragment.kt
@@ -12,7 +12,8 @@ import tv.teads.teadssdkdemo.format.mediation.identifier.AppLovinIdentifier
 import tv.teads.teadssdkdemo.utils.BaseFragment
 
 /**
- * Display inRead as Banner within a RecyclerView using AdMob Mediation.
+ * inRead format within a RecyclerView
+ *
  */
 class AppLovinRecyclerViewFragment : BaseFragment() {
     private lateinit var binding: FragmentRecyclerviewBinding
@@ -31,7 +32,7 @@ class AppLovinRecyclerViewFragment : BaseFragment() {
 
         val adUnit = AppLovinIdentifier.getAdUnitFromPid(pid)
 
-        recyclerView.adapter = AppLovinRecyclerViewAdapter(adUnit, context, getTitle())
+        recyclerView.adapter = AppLovinRecyclerViewAdapter(adUnit, requireContext(), getTitle())
     }
 
     override fun getTitle(): String = "InRead AdMob RecyclerView"

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/applovin/AppLovinScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/applovin/AppLovinScrollViewFragment.kt
@@ -20,6 +20,7 @@ import tv.teads.sdk.utils.userConsent.TCFVersion
 import tv.teads.teadssdkdemo.R
 import tv.teads.teadssdkdemo.data.SessionDataSource
 import tv.teads.teadssdkdemo.databinding.FragmentInreadScrollviewBinding
+import tv.teads.teadssdkdemo.format.inread.extensions.resizeAdContainer
 import tv.teads.teadssdkdemo.format.mediation.identifier.AppLovinIdentifier
 import tv.teads.teadssdkdemo.utils.BaseFragment
 
@@ -70,12 +71,7 @@ class AppLovinScrollViewFragment : BaseFragment() {
          */
         mListener = object : TeadsAdapterListener {
             override fun onRatioUpdated(adRatio: AdRatio) {
-                val params: ViewGroup.LayoutParams = adView.layoutParams
-
-                // Here the width is MATCH_PARENT
-                params.height = adRatio.calculateHeight(adView.measuredWidth)
-
-                adView.layoutParams = params
+                adView.resizeAdContainer(adRatio)
             }
 
             override fun adOpportunityTrackerView(trackerView: AdOpportunityTrackerView) {

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/applovin/AppLovinScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/applovin/AppLovinScrollViewFragment.kt
@@ -43,7 +43,7 @@ class AppLovinScrollViewFragment : BaseFragment() {
 
         // 2. Create MaxAdView view and add it to view hierarchy
         val adView = MaxAdView(AppLovinIdentifier.getAdUnitFromPid(pid), MaxAdFormat.MREC, context)
-        binding.adSlotView.addView(adView, 0)
+        binding.adSlotContainer.addView(adView, 0)
 
         // 3. Attach listener (will include Teads events)
         adView.setListener(object : MaxAdViewAdListener {
@@ -79,7 +79,7 @@ class AppLovinScrollViewFragment : BaseFragment() {
             }
 
             override fun adOpportunityTrackerView(trackerView: AdOpportunityTrackerView) {
-                binding.adSlotView.addView(trackerView)
+                binding.adSlotContainer.addView(trackerView)
             }
 
         }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/smart/SmartNativeGridRecyclerViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/smart/SmartNativeGridRecyclerViewFragment.kt
@@ -12,6 +12,10 @@ import tv.teads.teadssdkdemo.format.mediation.adapter.SmartNativeRecyclerViewAda
 import tv.teads.teadssdkdemo.utils.BaseFragment
 import tv.teads.teadssdkdemo.utils.MarginItemDecoration
 
+/**
+ * Native format within a RecyclerView
+ *
+ */
 class SmartNativeGridRecyclerViewFragment : BaseFragment() {
     private lateinit var binding: FragmentRecyclerviewBinding
 

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/smart/SmartNativeRecyclerViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/smart/SmartNativeRecyclerViewFragment.kt
@@ -12,6 +12,10 @@ import tv.teads.teadssdkdemo.format.mediation.adapter.SmartNativeRecyclerViewAda
 import tv.teads.teadssdkdemo.utils.BaseFragment
 import tv.teads.teadssdkdemo.utils.MarginItemDecoration
 
+/**
+ * Native format within a RecyclerView
+ *
+ */
 class SmartNativeRecyclerViewFragment : BaseFragment() {
     private lateinit var binding: FragmentRecyclerviewBinding
 

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/smart/SmartRecyclerViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/smart/SmartRecyclerViewFragment.kt
@@ -11,7 +11,8 @@ import tv.teads.teadssdkdemo.format.mediation.adapter.SmartRecyclerViewAdapter
 import tv.teads.teadssdkdemo.utils.BaseFragment
 
 /**
- * Display inRead as Banner within a RecyclerView using Smart Mediation.
+ * inRead format within a RecyclerView
+ *
  */
 class SmartRecyclerViewFragment : BaseFragment() {
     private lateinit var binding: FragmentRecyclerviewBinding

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/smart/SmartScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/smart/SmartScrollViewFragment.kt
@@ -43,7 +43,7 @@ class SmartScrollViewFragment : BaseFragment() {
 
         smartAdView.loadAd(bannerPlacement)
 
-        binding.adSlotView.addView(smartAdView)
+        binding.adSlotContainer.addView(smartAdView)
     }
 
     override fun getTitle(): String = "InRead Smart ScrollView"

--- a/TeadsSDKDemo/app/src/main/res/layout/fragment_inread_scrollview.xml
+++ b/TeadsSDKDemo/app/src/main/res/layout/fragment_inread_scrollview.xml
@@ -18,9 +18,9 @@
         <include layout="@layout/article_fake_lines" />
 
         <FrameLayout
-            android:id="@+id/adSlotView"
+            android:id="@+id/adSlotContainer"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="180dp" />
 
         <include layout="@layout/article_fake_lines" />
     </LinearLayout>

--- a/TeadsSDKDemo/app/src/main/res/layout/fragment_inread_scrollview.xml
+++ b/TeadsSDKDemo/app/src/main/res/layout/fragment_inread_scrollview.xml
@@ -20,7 +20,7 @@
         <FrameLayout
             android:id="@+id/adSlotContainer"
             android:layout_width="match_parent"
-            android:layout_height="180dp" />
+            android:layout_height="wrap_content" />
 
         <include layout="@layout/article_fake_lines" />
     </LinearLayout>


### PR DESCRIPTION
- `adRatio.calculateHeight(adSlotContainer.measuredWidth)` is made to received `measuredWidth` from the ad container view, not the ad view itself
- Create a view extension to easily apply the ad container resizing