### PR TITLE
CBC integration sample

### DIFF
--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/admob/AdMobScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/admob/AdMobScrollViewFragment.kt
@@ -44,6 +44,7 @@ class AdMobScrollViewFragment : BaseFragment() {
         // 2. Create AdMob view, setup and add it to view hierarchy
         val adView = AdView(view.context)
         adView.adUnitId = AdMobIdentifier.getAdUnitFromPid(pid)
+        // 💡 Despite the adSize from admob ad view is MEDIUM_RECTANGLE, Teads will serve different sort of ad sizes
         adView.setAdSize(AdSize.MEDIUM_RECTANGLE)
         binding.adSlotContainer.addView(adView, 0)
 
@@ -66,8 +67,7 @@ class AdMobScrollViewFragment : BaseFragment() {
             override fun onRatioUpdated(adRatio: AdRatio) {
                 val params: ViewGroup.LayoutParams = adView.layoutParams
 
-                // View container (binding.adSlotContainer where adView was added, check line 48)
-                // is height = WRAP_CONTENT
+                // 💡 View container (binding.adSlotContainer) height must be WRAP_CONTENT
                 params.height = adRatio.calculateHeight(adView.measuredWidth)
                 adView.layoutParams = params
             }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/admob/AdMobScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/format/mediation/admob/AdMobScrollViewFragment.kt
@@ -64,7 +64,12 @@ class AdMobScrollViewFragment : BaseFragment() {
          */
         mListener = object : TeadsAdapterListener {
             override fun onRatioUpdated(adRatio: AdRatio) {
-                binding.adSlotContainer.resizeAdContainer(adRatio)
+                val params: ViewGroup.LayoutParams = adView.layoutParams
+
+                // View container (binding.adSlotContainer where adView was added, check line 48)
+                // is height = WRAP_CONTENT
+                params.height = adRatio.calculateHeight(adView.measuredWidth)
+                adView.layoutParams = params
             }
 
             override fun adOpportunityTrackerView(trackerView: AdOpportunityTrackerView) {

--- a/TeadsSDKDemo/app/src/main/res/layout/fragment_inread_scrollview.xml
+++ b/TeadsSDKDemo/app/src/main/res/layout/fragment_inread_scrollview.xml
@@ -17,6 +17,7 @@
 
         <include layout="@layout/article_fake_lines" />
 
+        <!-- 💡 We have limit a bit the layout_width, but layout_height is wrap_content -->
         <FrameLayout
             android:id="@+id/adSlotContainer"
             android:layout_width="350dp"

--- a/TeadsSDKDemo/app/src/main/res/layout/fragment_inread_scrollview.xml
+++ b/TeadsSDKDemo/app/src/main/res/layout/fragment_inread_scrollview.xml
@@ -19,7 +19,8 @@
 
         <FrameLayout
             android:id="@+id/adSlotContainer"
-            android:layout_width="match_parent"
+            android:layout_width="350dp"
+            android:layout_gravity="center"
             android:layout_height="wrap_content" />
 
         <include layout="@layout/article_fake_lines" />

--- a/TeadsSDKDemo/app/src/main/res/layout/fragment_inread_scrollview.xml
+++ b/TeadsSDKDemo/app/src/main/res/layout/fragment_inread_scrollview.xml
@@ -17,7 +17,7 @@
 
         <include layout="@layout/article_fake_lines" />
 
-        <!-- 💡 We have limit a bit the layout_width, but layout_height is wrap_content -->
+        <!-- 💡 We can limit a bit the layout_width, but layout_height is wrap_content -->
         <FrameLayout
             android:id="@+id/adSlotContainer"
             android:layout_width="350dp"

--- a/TeadsSDKDemo/buildSrc/src/main/java/tv/teads/Libs.kt
+++ b/TeadsSDKDemo/buildSrc/src/main/java/tv/teads/Libs.kt
@@ -6,7 +6,7 @@ object Libs {
     const val APPLOVIN_SDK = "com.applovin:applovin-sdk:11.3.0"
 
     const val MATERIAL = "com.google.android.material:material:1.4.0"
-    const val PLAY_SERVICES_ADS = "com.google.android.gms:play-services-ads:23.0.0"
+    const val PLAY_SERVICES_ADS = "com.google.android.gms:play-services-ads:23.5.0"
 
     const val HUAWEI_IDENTIFIER = "com.huawei.hms:ads-identifier:3.4.28.313"
 

--- a/TeadsSDKDemo/gradle.properties
+++ b/TeadsSDKDemo/gradle.properties
@@ -19,5 +19,5 @@
 android.useAndroidX=true
 org.gradle.jvmargs=-Xms1024m -Xmx4096m
 
-VERSION_NAME=5.1.13
+VERSION_NAME=5.1.12
 VERSION_CODE=137


### PR DESCRIPTION
👋 Hello CBC team,

I see that your BaseAdsAdapter is changing the LayoutParams of the ad view container, which may be the root cause of the ad-resizing issues. Below are a few examples:

First, Teads is serving our **inRead** format through AdMob mediation. This format doesn’t serve only **MEDIUM_RECTANGLE**. Although the AdMob configuration requires you to set a specific ad size, Teads’ ad responses demand greater flexibility in your ad container’s dimensions. The **inRead** format is designed to accommodate a variety of ad sizes, as shown in the sample below.

| **INREAD, MANY SORTS OF AD SIZES**                                                | **CBC USES MEDIUM_RECTANGLE ALWAYS**                                          |
|-------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
| *ad resizing corrected; implemented with `ad view container = wrap_content`*                    | *Your ad view container constraint squeeze vertical ads and may cause ad resizing issues for other ads.* |
| <video controls width="400" src="https://github.com/user-attachments/assets/70d5a4bd-d8fc-4a8a-b44d-88c42cd62dbc"></video> | <img src="https://github.com/user-attachments/assets/b4101d47-ccc3-4f27-b409-39744daf1aaf" width="400" alt="Screenshot_2025-06-24-14-24-35-353" /> |




___


| **SAMPLE APP RENDERING IKEA AD**                                         | **CBC RENDERING IKEA AD**                                         |
|-------------------------------------------------------------------------------|-------------------------------------------------------------------|
| *ad resizing corrected; implemented with `ad view container = wrap_content`*  | *Ad view container and resizing not compliant*                    |
| <video controls src="https://github.com/user-attachments/assets/0b099891-fb80-4483-b799-f448d2690fe1" width="400"></video> | <img src="https://github.com/user-attachments/assets/7c91fd9e-e5ea-4955-bce1-0edbbf72ad30" width="400" alt="Screenshot 2025-07-30 at 14:33:48" /> 

___

Ad response with IKEA ad in order to test it map the path `r.teads.tv/*`: 
[inread_placeholder.json](https://github.com/user-attachments/files/21530471/inread_placeholder.json)
