### PR TITLE
ART-658: [Public Sample App] Add Interstitial Direct demo screen

### DIFF
--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/data/DemoSessionConfiguration.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/data/DemoSessionConfiguration.kt
@@ -37,6 +37,9 @@ object DemoSessionConfiguration {
     const val DEFAULT_INTERSTITIAL_ADMOB_PID = "ca-app-pub-3068786746829754/1230437446"
     const val DEFAULT_INTERSTITIAL_ADMOB_TESTING_PID = "ca-app-pub-3940256099942544/1033173712"
 
+    const val DEFAULT_INTERSTITIAL_DIRECT_WIDGET_ID = "INT_MW_1"
+    const val DEFAULT_INTERSTITIAL_DIRECT_ARTICLE_URL = "https://example.com/article"
+
     const val FAKE_TEADS_PREBID_TEST_SERVER =
         "https://tm3zwelt7nhxurh4rgapwm5smm0gywau.lambda-url.eu-west-1.on.aws/openrtb2/auction?verbose=true"
     const val PREBID_AD_CONFIG_ID = "imp-video-300x250"
@@ -113,6 +116,7 @@ object DemoSessionConfiguration {
         return when (getFormatOrDefault()) {
             FormatType.FEED -> DEFAULT_FEED_WIDGET_ID
             FormatType.RECOMMENDATIONS -> DEFAULT_RECOMMENDATIONS_WIDGET_ID
+            FormatType.INTERSTITIAL -> DEFAULT_INTERSTITIAL_DIRECT_WIDGET_ID
             else -> ""
         }
     }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/DemoViewModel.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/DemoViewModel.kt
@@ -121,6 +121,7 @@ class DemoViewModel : ViewModel() {
 
     // Provider types available for Interstitial format
     private val interstitialProviders = listOf(
+        ProviderType.DIRECT,
         ProviderType.ADMOB
     )
 
@@ -313,6 +314,12 @@ class DemoViewModel : ViewModel() {
 
             ProviderType.ADMOB to FormatType.INTERSTITIAL ->
                 updatePlacementId(DemoSessionConfiguration.DEFAULT_INTERSTITIAL_ADMOB_PID)
+
+            ProviderType.DIRECT to FormatType.INTERSTITIAL -> {
+                updateWidgetId(DemoSessionConfiguration.DEFAULT_INTERSTITIAL_DIRECT_WIDGET_ID)
+                updateInstallationKey(DemoSessionConfiguration.DEFAULT_INSTALLATION_KEY)
+                updateArticleUrl(DemoSessionConfiguration.DEFAULT_INTERSTITIAL_DIRECT_ARTICLE_URL)
+            }
         }
     }
 
@@ -394,8 +401,8 @@ class DemoViewModel : ViewModel() {
     }
 
     fun hasWidgetId(): Boolean {
-        return listOf(ProviderType.DIRECT).contains(selectedProvider)
-                && listOf(FormatType.FEED, FormatType.RECOMMENDATIONS).contains(selectedFormat)
+        return selectedProvider == ProviderType.DIRECT
+                && selectedFormat in listOf(FormatType.FEED, FormatType.RECOMMENDATIONS, FormatType.INTERSTITIAL)
     }
 
     fun getInputMethod(): KeyboardType = when (selectedProvider to selectedFormat) {
@@ -417,6 +424,7 @@ class DemoViewModel : ViewModel() {
     fun getWidgetChips(): List<ChipData> = when (selectedProvider to selectedFormat) {
         ProviderType.DIRECT to FormatType.FEED -> getFeedWidgetIdChips()
         ProviderType.DIRECT to FormatType.RECOMMENDATIONS -> getRecommendationsWidgetIdChips()
+        ProviderType.DIRECT to FormatType.INTERSTITIAL -> emptyList()
         else -> throw IllegalAccessException("Impossible combination")
     }
 
@@ -534,6 +542,7 @@ class DemoViewModel : ViewModel() {
     fun getInstallationKeyChips(): List<ChipData> = when (selectedProvider to selectedFormat) {
         ProviderType.DIRECT to FormatType.FEED -> getFeedInstallationKeyChips()
         ProviderType.DIRECT to FormatType.RECOMMENDATIONS -> getRecommendationsInstallationKeyChips()
+        ProviderType.DIRECT to FormatType.INTERSTITIAL -> emptyList()
         else -> throw IllegalAccessException("Impossible combination")
     }
 

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/MainActivity.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/MainActivity.kt
@@ -32,6 +32,7 @@ import tv.teads.teadssdkdemo.v6.ui.base.navigation.NavigationHandler
 import tv.teads.teadssdkdemo.v6.ui.base.navigation.Route
 import tv.teads.teadssdkdemo.v6.ui.base.theme.TeadsSDKDemoTheme
 import tv.teads.teadssdkdemo.v6.ui.compose.InterstitialAdmobColumnScreen
+import tv.teads.teadssdkdemo.v6.ui.compose.InterstitialDirectColumnScreen
 import tv.teads.teadssdkdemo.v6.ui.compose.FeedColumnScreen
 import tv.teads.teadssdkdemo.v6.ui.compose.FeedLazyColumnScreen
 import tv.teads.teadssdkdemo.v6.ui.compose.MediaAdmobColumnScreen
@@ -94,6 +95,7 @@ class MainActivity : ComponentActivity() {
                                         Route.RecommendationsColumn -> "Recommendations Column"
                                         Route.RecommendationsLazyColumn -> "Recommendations LazyColumn"
                                         Route.InterstitialAdMobColumn -> "Interstitial AdMob Column"
+                                        Route.InterstitialDirectColumn -> "Interstitial Direct Column"
                                         else -> "Teads SDK Demo"
                                     },
                                     style = MaterialTheme.typography.titleLarge.copy(
@@ -116,7 +118,7 @@ class MainActivity : ComponentActivity() {
                                     Route.MediaSmartColumn, Route.MediaNativeSmartColumn,
                                     Route.FeedColumn, Route.FeedLazyColumn,
                                     Route.RecommendationsColumn, Route.RecommendationsLazyColumn,
-                                    Route.InterstitialAdMobColumn -> {
+                                    Route.InterstitialAdMobColumn, Route.InterstitialDirectColumn -> {
                                         IconButton(onClick = { currentRoute = Route.Demo }) {
                                             Icon(
                                                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -144,7 +146,7 @@ class MainActivity : ComponentActivity() {
                                     Route.MediaSmartColumn, Route.MediaNativeSmartColumn,
                                     Route.FeedColumn, Route.FeedLazyColumn,
                                     Route.RecommendationsColumn, Route.RecommendationsLazyColumn,
-                                    Route.InterstitialAdMobColumn -> {
+                                    Route.InterstitialAdMobColumn, Route.InterstitialDirectColumn -> {
                                         currentRoute = navRoute
                                     }
                                     else -> {
@@ -238,6 +240,12 @@ class MainActivity : ComponentActivity() {
                         }
                         Route.InterstitialAdMobColumn -> {
                             InterstitialAdmobColumnScreen(
+                                modifier = Modifier.padding(paddingValues),
+                                activity = this@MainActivity
+                            )
+                        }
+                        Route.InterstitialDirectColumn -> {
+                            InterstitialDirectColumnScreen(
                                 modifier = Modifier.padding(paddingValues),
                                 activity = this@MainActivity
                             )

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/navigation/Routes.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/navigation/Routes.kt
@@ -61,6 +61,7 @@ sealed class Route {
     data object RecommendationsColumn : Route()
     data object RecommendationsLazyColumn : Route()
     data object InterstitialAdMobColumn : Route()
+    data object InterstitialDirectColumn : Route()
 }
 
 /**
@@ -179,6 +180,12 @@ object RouteFactory {
                     else -> throw IllegalAccessException("Impossible route")
                 }
             }
+            format == FormatType.INTERSTITIAL && provider == ProviderType.DIRECT -> {
+                when (integration) {
+                    IntegrationType.COLUMN -> Route.InterstitialDirectColumn
+                    else -> throw IllegalAccessException("Impossible route")
+                }
+            }
             else -> throw IllegalAccessException("Impossible route")
         }
     }
@@ -276,5 +283,6 @@ fun Route.getTitle(): String {
         Route.RecommendationsLazyColumn -> "Recommendations LazyColumn"
         Route.MediaAdMobScrollView -> "Media AdMob ScrollView"
         Route.InterstitialAdMobColumn -> "Interstitial AdMob Column"
+        Route.InterstitialDirectColumn -> "Interstitial Direct Column"
     }
 }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/InterstitialDirectColumnScreen.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/InterstitialDirectColumnScreen.kt
@@ -1,0 +1,259 @@
+package tv.teads.teadssdkdemo.v6.ui.compose
+
+import android.app.Activity
+import android.content.Context
+import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import tv.teads.sdk.TeadsSDK
+import tv.teads.sdk.combinedsdk.TeadsAdPlacementEventName
+import tv.teads.sdk.combinedsdk.adplacement.TeadsAdPlacementInterstitial
+import tv.teads.sdk.combinedsdk.adplacement.config.TeadsAdPlacementInterstitialConfig
+import tv.teads.sdk.combinedsdk.adplacement.interfaces.TeadsAdPlacementEventsDelegate
+import tv.teads.sdk.combinedsdk.adplacement.interfaces.core.TeadsAdPlacement
+import tv.teads.teadssdkdemo.BuildConfig
+import tv.teads.teadssdkdemo.R
+import tv.teads.teadssdkdemo.v6.data.DemoSessionConfiguration
+import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleBody
+import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleLabel
+import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleSpacing
+import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleTitle
+
+private const val TAG = "InterstitialDirect"
+
+@Composable
+fun InterstitialDirectColumnScreen(
+    modifier: Modifier = Modifier,
+    activity: Activity
+) {
+    val context = LocalContext.current
+    var isContentUnlocked by remember { mutableStateOf(false) }
+    var isWaitingForAd by remember { mutableStateOf(false) }
+    var isAdReady by remember { mutableStateOf(false) }
+    var placement by remember { mutableStateOf<TeadsAdPlacementInterstitial?>(null) }
+
+    LaunchedEffect(Unit) {
+        // 0. Init SDK
+        TeadsSDK.configure(
+            applicationContext = context.applicationContext,
+            appKey = "AndroidSampleApp2014"
+        )
+        if (BuildConfig.DEBUG) {
+            TeadsSDK.testMode = true
+        }
+
+        // 1. Init configuration
+        val config = TeadsAdPlacementInterstitialConfig(
+            articleUrl = DemoSessionConfiguration.getArticleUrlOrDefault(),
+            widgetId = DemoSessionConfiguration.getWidgetIdOrDefault(),
+            installationKey = DemoSessionConfiguration.getInstallationKeyOrDefault()
+        )
+
+        // 2. Create placement — context must be an Activity (SDK attaches a hidden WebView to content view)
+        val interstitial = TeadsAdPlacementInterstitial(
+            context = activity,
+            config = config,
+            delegate = { placement, event, data ->
+                Log.d(TAG, "$event: $data")
+                when (event) {
+                    TeadsAdPlacementEventName.READY -> {
+                        isAdReady = true
+                        // 4. If the user already requested to see the ad, show it now
+                        if (isWaitingForAd) {
+                            (placement as? TeadsAdPlacementInterstitial)?.show(activity)
+                        }
+                    }
+
+                    TeadsAdPlacementEventName.FAILED -> {
+                        isAdReady = false
+                        isContentUnlocked = true
+                        isWaitingForAd = false
+                    }
+
+                    TeadsAdPlacementEventName.DISMISSED -> {
+                        isAdReady = false
+                        isContentUnlocked = true
+                        isWaitingForAd = false
+                    }
+
+                    else -> Unit
+                }
+            }
+        )
+        placement = interstitial
+
+        // 3. Request ad
+        interstitial.loadAd()
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { placement?.clean() }
+    }
+
+    // Sample use case: article with a paywall that triggers the interstitial ad
+    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        val screenHeight = maxHeight
+        val density = LocalDensity.current
+        var articleContentHeight by remember { mutableStateOf(0.dp) }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.Top,
+        ) {
+            Column(
+                modifier = Modifier.onGloballyPositioned { coordinates ->
+                    articleContentHeight = with(density) { coordinates.size.height.toDp() }
+                }
+            ) {
+                ArticleLabel()
+                ArticleSpacing()
+                ArticleTitle()
+                ArticleSpacing()
+                ArticleBody(text = stringResource(R.string.article_template_body_a))
+                ArticleSpacing()
+            }
+
+            if (!isContentUnlocked) {
+                val paywallMinHeight = (screenHeight - articleContentHeight).coerceAtLeast(300.dp)
+
+                InterstitialDirectPaywallOverlay(
+                    isWaitingForAd = isWaitingForAd,
+                    minHeight = paywallMinHeight,
+                    onWatchAdClick = {
+                        val ad = placement
+                        if (isAdReady && ad != null) {
+                            // 5. Show the ad
+                            ad.show(activity)
+                        } else {
+                            isWaitingForAd = true
+                        }
+                    }
+                )
+            } else {
+                ArticleBody(text = stringResource(R.string.article_template_body_b))
+                ArticleSpacing()
+                ArticleBody(text = stringResource(R.string.article_template_body_c))
+                ArticleSpacing()
+                ArticleBody(text = stringResource(R.string.article_template_body_d))
+                ArticleSpacing()
+                ArticleBody(text = stringResource(R.string.article_template_body_e))
+            }
+        }
+    }
+}
+
+@Composable
+private fun InterstitialDirectPaywallOverlay(
+    isWaitingForAd: Boolean,
+    minHeight: androidx.compose.ui.unit.Dp,
+    onWatchAdClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = minHeight)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(120.dp)
+        ) {
+            ArticleBody(
+                text = stringResource(R.string.article_template_body_b),
+                modifier = Modifier.padding(bottom = 40.dp)
+            )
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                Color.Transparent,
+                                MaterialTheme.colorScheme.surface
+                            )
+                        )
+                    )
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 80.dp)
+                .heightIn(min = (minHeight - 80.dp).coerceAtLeast(0.dp))
+                .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "Premium Content",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = "See ad to read the rest of the content",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (isWaitingForAd) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(32.dp),
+                    color = MaterialTheme.colorScheme.primary
+                )
+            } else {
+                Button(onClick = onWatchAdClick) {
+                    Text("Watch Ad")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds a new Interstitial integration driven by the Teads SDK's direct API (`TeadsAdPlacementInterstitial`), alongside the existing AdMob-mediated Interstitial demo.

## Problem
- The v6 demo only exposed `Format=Interstitial` via the AdMob provider.
- There was no demo showcasing `TeadsAdPlacementInterstitial` + `TeadsAdPlacementInterstitialConfig` directly, which is the path documented for publishers using the Teads SDK without a mediator.

## Solution
1. Added `Direct` as the first provider chip under `Format=Interstitial` (AdMob remains second).
2. For `Interstitial + Direct`, the Placement Configuration section reuses the Feed-style inputs (Article URL, Widget ID, Installation Key), pre-filled with demo defaults. No preset chips are shown — users must type their own values to override.
3. Display Mode section stays collapsed for Interstitial (unchanged — falls through existing `shouldShowDisplayModeSection` logic).
4. Integration chips are limited to `Column`.
5. New composable screen mirrors the AdMob paywall layout ("Watch Ad" button unlocking the rest of the article), but drives `TeadsAdPlacementInterstitial` directly.

## Changes
| File | Change |
| --- | --- |
| `app/src/main/java/tv/teads/teadssdkdemo/v6/data/DemoSessionConfiguration.kt` | Added `DEFAULT_INTERSTITIAL_DIRECT_WIDGET_ID` and `DEFAULT_INTERSTITIAL_DIRECT_ARTICLE_URL`; `getWidgetIdOrDefault()` returns the Direct widget id for `Interstitial`. |
| `app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/DemoViewModel.kt` | `interstitialProviders` now `[DIRECT, ADMOB]`. `hasWidgetId()` extended to cover `Direct + Interstitial`. `getWidgetChips()` / `getInstallationKeyChips()` return empty lists for this combo. `updatePlacementConfiguration()` seeds defaults when switching to Direct+Interstitial. |
| `app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/navigation/Routes.kt` | New `Route.InterstitialDirectColumn`, route factory entry, and title. |
| `app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/MainActivity.kt` | Imports + wires the new route into the top bar title, back-button group, compose-route whitelist, and screen rendering. |
| `app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/InterstitialDirectColumnScreen.kt` | New Compose screen: configures `TeadsSDK`, creates `TeadsAdPlacementInterstitial`, handles READY/FAILED/DISMISSED to drive paywall state, cleans up on dispose. |

## Test Plan
- [ ] `./gradlew :app:assembleDebug` builds cleanly.
- [ ] Launch demo → `Format=Interstitial` → provider chips render as `Direct`, `AdMob` (in that order).
- [ ] Select `Direct` → Placement Configurations show Article URL `https://example.com/article`, Widget ID `INT_MW_1`, Installation Key `NANOWDGT01`, with no preset chips under Widget ID or Installation Key.
- [ ] Display Mode section is hidden for `Interstitial + Direct`.
- [ ] Integration chips show only `Column`.
- [ ] Tap `LAUNCH ARTICLE` → new screen renders article + paywall.
- [ ] Tap "Watch Ad" when ad is loaded → fullscreen Teads interstitial presents; dismissing it unlocks the rest of the article.
- [ ] Tap "Watch Ad" before ad loads → spinner appears; ad auto-presents when ready.
- [ ] Entering a bogus `widgetId` → `FAILED` event → content still unlocks (matches AdMob screen behavior).
- [ ] Regression: `Interstitial + AdMob` existing flow still works end-to-end.