### PR TITLE
[DRAFT / TEMPORARY] Demo: consuming Teads SDK 6.1.0 from a Kotlin 1.9.24 multi-module project

### DIFF
--- a/KOTLIN_1.9.24_COMPAT_NOTES.md
+++ b/KOTLIN_1.9.24_COMPAT_NOTES.md
@@ -1,0 +1,102 @@
+# Consuming the Teads SDK from a Kotlin 1.9.24 project
+
+This branch demonstrates how to build and use the Teads Android SDK (6.1.0) from an
+application module that is pinned to **Kotlin 1.9.24**.
+
+## Why a workaround is needed
+
+Since June 2025 (SDK 6.1.0 onwards), the Teads SDK is compiled with Kotlin Gradle
+Plugin **2.1.21**. Two things propagate to consumers:
+
+1. The published artifact declares `org.jetbrains.kotlin:kotlin-stdlib:2.1.21` as a
+   transitive `compile`-scope dependency — so Gradle will resolve stdlib 2.1.21 on
+   your classpath.
+2. The SDK's `.class` files carry **Kotlin metadata version 2.1.0**.
+
+Kotlin's compatibility rules are asymmetric:
+
+| Direction | Compatible? |
+|---|---|
+| **Runtime stdlib** newer than the consumer's compiler | ✅ (forward-compatible: stdlib >= compiler version) |
+| **Kotlin metadata** newer than the consumer's compiler | ❌ — the compiler refuses to read it by default |
+
+Kotlin 1.9.x can read metadata up to version **2.0** out of the box. Reading
+metadata 2.1 requires an explicit opt-in.
+
+Without the workaround, building our sample app on Kotlin 1.9.24 fails with
+dozens of errors like:
+
+```
+Class 'tv.teads.sdk.TeadsSDK' was compiled with an incompatible version of Kotlin.
+The actual metadata version is 2.1.0, but the compiler version 1.9.0 can read versions up to 2.0.0.
+```
+
+## The workaround (one compiler flag)
+
+Add the following to your **app module's** `build.gradle.kts`:
+
+```kotlin
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        freeCompilerArgs = freeCompilerArgs + "-Xskip-metadata-version-check"
+    }
+}
+```
+
+Or in Groovy (`build.gradle`):
+
+```groovy
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        freeCompilerArgs += "-Xskip-metadata-version-check"
+    }
+}
+```
+
+That's the only change required. No need to upgrade the application's Kotlin
+compiler, and no `resolutionStrategy` / stdlib pinning is needed — Gradle's
+default resolution already picks the higher stdlib (2.1.21) pulled in by the
+Teads SDK, which is the correct outcome (stdlib is forward-compatible with
+code compiled by a lower Kotlin version).
+
+## Is this safe?
+
+Yes, in the practical sense. `-Xskip-metadata-version-check` tells the 1.9
+compiler to trust metadata newer than what it was designed to read. The Teads
+SDK's public API does **not** use any Kotlin 2.x-only language feature (e.g.
+context receivers) — so the symbols exposed are all representable in Kotlin
+1.9. The flag is the standard JetBrains-recommended approach for this exact
+situation.
+
+`kotlin-stdlib:2.1.21` on the classpath is forward-compatible with code
+compiled by Kotlin 1.9.24 — stdlib never breaks backwards-binary-compat.
+
+## Long-term recommendation
+
+This workaround is intended as a **bridge** for publishers who can't upgrade
+their Kotlin compiler immediately. The clean long-term solution is for the app
+to upgrade to Kotlin **1.9.x -> 2.0.x or 2.1.x**. Kotlin 2.x is source-compatible
+with virtually all 1.9 code and the upgrade is usually a one-line change in
+the plugin version plus a Gradle sync.
+
+## What this branch changed vs. `master`
+
+| File | Change |
+|---|---|
+| `TeadsSDKDemo/buildSrc/src/main/java/tv/teads/Versions.kt` | Kotlin `2.1.21` -> `1.9.24`; Compose BOM `2025.09.01` -> `2024.06.00`; added `composeCompiler = "1.5.14"` |
+| `TeadsSDKDemo/buildSrc/build.gradle.kts` | Kotlin Gradle Plugin `2.1.21` -> `1.9.24`; removed `compose-compiler-gradle-plugin` (Kotlin 2.0+ only) |
+| `TeadsSDKDemo/app/build.gradle.kts` | Removed `org.jetbrains.kotlin.plugin.compose`; added `composeOptions { kotlinCompilerExtensionVersion = "1.5.14" }`; added the `-Xskip-metadata-version-check` compiler flag |
+
+## Verified build
+
+```
+./gradlew :app:assembleDebug
+...
+BUILD SUCCESSFUL in 12s
+```
+
+---
+
+*This branch (`test/publisher-kotlin-1.9.24-compat`) is for demonstration only.*
+*It will not be merged and will be deleted once the referencing publisher has
+integrated the workaround on their side.*

--- a/KOTLIN_1.9.24_COMPAT_NOTES.md
+++ b/KOTLIN_1.9.24_COMPAT_NOTES.md
@@ -31,14 +31,18 @@ Class 'tv.teads.sdk.TeadsSDK' was compiled with an incompatible version of Kotli
 The actual metadata version is 2.1.0, but the compiler version 1.9.0 can read versions up to 2.0.0.
 ```
 
-## The workaround (one compiler flag)
+## The workaround (one compiler flag, applied project-wide)
 
-Add the following to your **app module's** `build.gradle.kts`:
+Add the following to your **root** `build.gradle.kts` (i.e. the build script
+at the top of the project, alongside `settings.gradle.kts`) — **not** inside
+any individual module:
 
 ```kotlin
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    kotlinOptions {
-        freeCompilerArgs = freeCompilerArgs + "-Xskip-metadata-version-check"
+subprojects {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        kotlinOptions {
+            freeCompilerArgs = freeCompilerArgs + "-Xskip-metadata-version-check"
+        }
     }
 }
 ```
@@ -46,20 +50,62 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
 Or in Groovy (`build.gradle`):
 
 ```groovy
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        freeCompilerArgs += "-Xskip-metadata-version-check"
+subprojects {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+        kotlinOptions {
+            freeCompilerArgs += "-Xskip-metadata-version-check"
+        }
     }
 }
 ```
 
-That's the only change required. No need to upgrade the application's Kotlin
-compiler, and no `resolutionStrategy` / stdlib pinning is needed — Gradle's
-default resolution already picks the higher stdlib (2.1.21) pulled in by the
-Teads SDK, which is the correct outcome (stdlib is forward-compatible with
-code compiled by a lower Kotlin version).
+### Why root-level and not per-module?
+
+In Gradle, `tasks.withType<KotlinCompile>().configureEach { … }` is
+**project-scoped** — it only configures tasks in the module that declares it.
+A multi-module app where only the `:app` module sets the flag will still fail
+to compile any sibling library module that touches the Teads SDK.
+
+Wrapping the block in `subprojects { }` from the **root** build script
+applies the same configuration to every submodule with a single, maintainable
+declaration. No need to copy the snippet into each module's `build.gradle.kts`.
+
+If your project already uses `buildSrc` convention plugins, putting the same
+`tasks.withType<KotlinCompile>` block inside a shared convention plugin is an
+equally clean alternative.
+
+### What's *not* needed
+
+That `subprojects { }` block is the only build-script change required. No
+need to upgrade the application's Kotlin compiler, and no
+`resolutionStrategy` / stdlib pinning is needed — Gradle's default resolution
+already picks the higher stdlib (2.1.21) pulled in by the Teads SDK, which is
+the correct outcome (stdlib is forward-compatible with code compiled by a
+lower Kotlin version).
 
 ## Is this safe?
+
+> ### ℹ️ Heads-up: this flag applies to your whole classpath
+>
+> `-Xskip-metadata-version-check` is a compiler-wide setting — it relaxes
+> the metadata version check for **every** dependency the Kotlin compiler
+> reads, not just Teads. In practice this is fine for the vast majority of
+> projects, but it's worth knowing:
+>
+> - **For Teads:** safe by design. The Teads SDK's public API uses only
+>   features representable in Kotlin 1.9 (no context receivers, no Kotlin
+>   2.x-only constructs).
+> - **For other SDKs you depend on:** they're treated the same way. If
+>   another library you use is compiled with Kotlin ≥ 2.1 *and* exposes a
+>   Kotlin 2.x-only feature in its public API *and* your code touches that
+>   feature, you may see compile-time or runtime issues from that
+>   library — not from Teads.
+>
+> If a non-Teads dependency starts misbehaving after enabling this flag,
+> that's a useful signal that the dependency in question is itself
+> incompatible with Kotlin 1.9. The cleanest long-term path remains
+> upgrading the app's compiler to Kotlin 2.x (see below) — at which point
+> the flag becomes unnecessary for everyone.
 
 Yes, in the practical sense. `-Xskip-metadata-version-check` tells the 1.9
 compiler to trust metadata newer than what it was designed to read. The Teads
@@ -85,14 +131,28 @@ the plugin version plus a Gradle sync.
 |---|---|
 | `TeadsSDKDemo/buildSrc/src/main/java/tv/teads/Versions.kt` | Kotlin `2.1.21` -> `1.9.24`; Compose BOM `2025.09.01` -> `2024.06.00`; added `composeCompiler = "1.5.14"` |
 | `TeadsSDKDemo/buildSrc/build.gradle.kts` | Kotlin Gradle Plugin `2.1.21` -> `1.9.24`; removed `compose-compiler-gradle-plugin` (Kotlin 2.0+ only) |
-| `TeadsSDKDemo/app/build.gradle.kts` | Removed `org.jetbrains.kotlin.plugin.compose`; added `composeOptions { kotlinCompilerExtensionVersion = "1.5.14" }`; added the `-Xskip-metadata-version-check` compiler flag |
+| `TeadsSDKDemo/build.gradle.kts` | Added the root-level `subprojects { }` block applying `-Xskip-metadata-version-check` to every submodule |
+| `TeadsSDKDemo/settings.gradle.kts` | Added `include(":feature-foo")` so the demo is genuinely multi-module |
+| `TeadsSDKDemo/app/build.gradle.kts` | Removed `org.jetbrains.kotlin.plugin.compose`; added `composeOptions { kotlinCompilerExtensionVersion = "1.5.14" }`; depends on the new `:feature-foo` library module. The per-module `-Xskip-metadata-version-check` block was *not* added — it's handled at the root |
+| `TeadsSDKDemo/feature-foo/` | NEW library module that consumes `TeadsSDK.configure(...)`. Used to reproduce the multi-module failure mode and prove the root-level fix works |
 
 ## Verified build
+
+End-to-end multi-module check, with the flag declared **only** at the root:
 
 ```
 ./gradlew :app:assembleDebug
 ...
-BUILD SUCCESSFUL in 12s
+BUILD SUCCESSFUL in 41s
+```
+
+Both `:app` and `:feature-foo` compile from the single root-level
+`subprojects { }` declaration. Removing the root block (or moving it back
+inside `:app`) reproduces the publisher's failure on `:feature-foo`:
+
+```
+e: Class 'tv.teads.sdk.TeadsSDK' was compiled with an incompatible version of Kotlin.
+   The actual metadata version is 2.1.0, but the compiler version 1.9.0 can read versions up to 2.0.0.
 ```
 
 ---

--- a/TeadsSDKDemo/app/build.gradle.kts
+++ b/TeadsSDKDemo/app/build.gradle.kts
@@ -1,12 +1,14 @@
 import tv.teads.AndroidLibConfig
 import tv.teads.Libs
+import tv.teads.Versions
 import tv.teads.versionCode
 import tv.teads.versionName
 
 plugins {
     id("com.android.application")
     id("kotlin-android")
-    id("org.jetbrains.kotlin.plugin.compose")
+    // NOTE: org.jetbrains.kotlin.plugin.compose is Kotlin 2.0+ only.
+    // On Kotlin 1.9.24 we use the legacy composeOptions block below.
 }
 
 android {
@@ -50,6 +52,31 @@ android {
     buildFeatures {
         viewBinding = true
         buildConfig = true
+        compose = true
+    }
+
+    // Kotlin 1.9.24 uses the legacy Compose compiler extension path.
+    composeOptions {
+        kotlinCompilerExtensionVersion = Versions.composeCompiler
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Publisher-on-Kotlin-1.9.24 workaround
+// ---------------------------------------------------------------------------
+// The Teads SDK is compiled with Kotlin 2.1.21 and its class files carry
+// Kotlin metadata version 2.1.0. Compiler 1.9.x can only read up to metadata
+// 2.0 by default and will fail with:
+//   "Class '...' was compiled with an incompatible version of Kotlin.
+//    The actual metadata version is 2.1.0, but the compiler version 1.9.0
+//    can read versions up to 2.0.0."
+// This flag tells the 1.9 compiler to trust and read the newer metadata.
+// Safe because the SDK's public API does not expose any Kotlin 2.x-only
+// language feature.
+// ---------------------------------------------------------------------------
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        freeCompilerArgs = freeCompilerArgs + "-Xskip-metadata-version-check"
     }
 }
 

--- a/TeadsSDKDemo/app/build.gradle.kts
+++ b/TeadsSDKDemo/app/build.gradle.kts
@@ -61,24 +61,9 @@ android {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Publisher-on-Kotlin-1.9.24 workaround
-// ---------------------------------------------------------------------------
-// The Teads SDK is compiled with Kotlin 2.1.21 and its class files carry
-// Kotlin metadata version 2.1.0. Compiler 1.9.x can only read up to metadata
-// 2.0 by default and will fail with:
-//   "Class '...' was compiled with an incompatible version of Kotlin.
-//    The actual metadata version is 2.1.0, but the compiler version 1.9.0
-//    can read versions up to 2.0.0."
-// This flag tells the 1.9 compiler to trust and read the newer metadata.
-// Safe because the SDK's public API does not expose any Kotlin 2.x-only
-// language feature.
-// ---------------------------------------------------------------------------
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    kotlinOptions {
-        freeCompilerArgs = freeCompilerArgs + "-Xskip-metadata-version-check"
-    }
-}
+// NOTE: the Kotlin-1.9.24 metadata-compat flag is applied project-wide from
+// the root build.gradle.kts via `subprojects { }`, so no per-module override
+// is needed here.
 
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
@@ -131,6 +116,9 @@ dependencies {
     // ViewModel for Compose
     implementation(Libs.Compose.LIFECYCLE_VIEWMODEL_COMPOSE)
     implementation(Libs.Compose.LIFECYCLE_RUNTIME_COMPOSE)
+
+    // Multi-module repro: a sibling library module that also consumes the Teads SDK.
+    implementation(project(":feature-foo"))
 
     // Testing
     testImplementation(Libs.Test.JUNIT)

--- a/TeadsSDKDemo/build.gradle.kts
+++ b/TeadsSDKDemo/build.gradle.kts
@@ -1,3 +1,24 @@
+// ---------------------------------------------------------------------------
+// Publisher-on-Kotlin-1.9.24 workaround — applied project-wide
+// ---------------------------------------------------------------------------
+// The Teads SDK is compiled with Kotlin 2.1.21; its class files carry Kotlin
+// metadata version 2.1.0. Compiler 1.9.x can only read up to metadata 2.0 by
+// default. Without this flag any module that touches the Teads SDK API fails
+// with: "Class '...' was compiled with an incompatible version of Kotlin."
+//
+// `tasks.withType(...)` is project-scoped, so configuring it inside a single
+// module's build.gradle.kts only fixes that module. Wrapping it in
+// `subprojects { }` from the root build script applies the flag to every
+// submodule with a single, maintainable declaration.
+// ---------------------------------------------------------------------------
+subprojects {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        kotlinOptions {
+            freeCompilerArgs = freeCompilerArgs + "-Xskip-metadata-version-check"
+        }
+    }
+}
+
 tasks.register("clean", Delete::class) {
     delete(rootProject.layout.buildDirectory)
 }

--- a/TeadsSDKDemo/buildSrc/build.gradle.kts
+++ b/TeadsSDKDemo/buildSrc/build.gradle.kts
@@ -9,6 +9,8 @@ repositories {
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.6.0")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.21")
-    implementation("org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.1.21")
+    // Pinned to 1.9.24 to simulate a publisher on that Kotlin version.
+    // The compose-compiler-gradle-plugin does NOT exist for 1.9.x — we use
+    // the legacy composeOptions { kotlinCompilerExtensionVersion = ... } in the app module instead.
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
 }

--- a/TeadsSDKDemo/buildSrc/src/main/java/tv/teads/Versions.kt
+++ b/TeadsSDKDemo/buildSrc/src/main/java/tv/teads/Versions.kt
@@ -11,8 +11,14 @@ object Versions {
     const val targetSdk = 35
     
     // Kotlin and Compose
-    const val kotlin = "2.1.21"
-    const val composeBom = "2025.09.01"
+    // NOTE: Pinned to 1.9.24 to simulate a publisher stuck on that compiler.
+    // The Teads SDK still pulls kotlin-stdlib:2.1.21 transitively, which is
+    // fine because Kotlin's compatibility rule is stdlib >= compiler version.
+    const val kotlin = "1.9.24"
+    // Compose BOM compatible with compose-compiler 1.5.14 (last version built for Kotlin 1.9.24).
+    const val composeBom = "2024.06.00"
+    // Compose compiler extension version — must match the Kotlin compiler version.
+    const val composeCompiler = "1.5.14"
     
     // AndroidX Core
     const val appcompat = "1.3.0"

--- a/TeadsSDKDemo/feature-foo/build.gradle.kts
+++ b/TeadsSDKDemo/feature-foo/build.gradle.kts
@@ -1,0 +1,32 @@
+import tv.teads.AndroidLibConfig
+import tv.teads.Libs
+import tv.teads.versionName
+
+plugins {
+    id("com.android.library")
+    id("kotlin-android")
+}
+
+android {
+    namespace = "tv.teads.featurefoo"
+    compileSdk = AndroidLibConfig.compileSdk
+
+    defaultConfig {
+        minSdk = AndroidLibConfig.minSdk
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation(Libs.Teads.sdk(project.versionName)) {
+        isTransitive = true
+    }
+}

--- a/TeadsSDKDemo/feature-foo/src/main/AndroidManifest.xml
+++ b/TeadsSDKDemo/feature-foo/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/TeadsSDKDemo/feature-foo/src/main/java/tv/teads/featurefoo/FooTeadsCaller.kt
+++ b/TeadsSDKDemo/feature-foo/src/main/java/tv/teads/featurefoo/FooTeadsCaller.kt
@@ -1,0 +1,10 @@
+package tv.teads.featurefoo
+
+import android.content.Context
+import tv.teads.sdk.TeadsSDK
+
+object FooTeadsCaller {
+    fun init(context: Context, appKey: String) {
+        TeadsSDK.configure(context, appKey)
+    }
+}

--- a/TeadsSDKDemo/settings.gradle.kts
+++ b/TeadsSDKDemo/settings.gradle.kts
@@ -23,3 +23,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "TeadsSDK_Demo"
 include(":app")
+include(":feature-foo")


### PR DESCRIPTION
## Summary

Demonstrates how to consume the Teads Android SDK `6.1.0` from a **multi-module** project pinned to Kotlin `1.9.24`, and documents the single compiler flag required to unblock the build — applied **once at the root** so it covers every submodule.

> **Draft / temporary** — this branch is not intended to be merged.

## Problem

Since SDK `6.1.0` (June 2025) the Teads SDK is compiled with Kotlin Gradle Plugin `2.1.21`. Two things propagate to consumers:

1. The published artifact declares `org.jetbrains.kotlin:kotlin-stdlib:2.1.21` as a transitive `compile`-scope dependency.
2. The SDK's `.class` files carry **Kotlin metadata version `2.1.0`**.

Kotlin's compatibility rules are asymmetric:

| Direction | Compatible? |
|---|---|
| **Runtime stdlib** newer than the consumer's compiler | ✅ (stdlib is forward-compatible; stdlib ≥ compiler version is the rule) |
| **Kotlin metadata** newer than the consumer's compiler | ❌ — the compiler refuses to read it by default |

Kotlin `1.9.x` reads metadata up to `2.0` out of the box. Reading metadata `2.1` requires an explicit opt-in.

Without the workaround, a consumer on Kotlin `1.9.24` hits dozens of hard errors like:

```
Class 'tv.teads.sdk.TeadsSDK' was compiled with an incompatible version of Kotlin.
The actual metadata version is 2.1.0, but the compiler version 1.9.0 can read versions up to 2.0.0.
```

> ### ℹ️ Heads-up: this flag applies to the whole classpath
>
> `-Xskip-metadata-version-check` is a compiler-wide setting — it relaxes the metadata version check for **every** dependency the Kotlin compiler reads, not just Teads. In practice this is fine for the vast majority of projects, but it's worth flagging so we're all on the same page:
>
> - **For Teads:** safe by design. The Teads SDK's public API uses only features representable in Kotlin 1.9 (no context receivers, no Kotlin 2.x-only constructs).
> - **For other SDKs in the publisher's project:** they're treated the same way. If another library is compiled with Kotlin ≥ 2.1 *and* exposes a Kotlin 2.x-only feature in its public API *and* the publisher's code touches that feature, the resulting compile/runtime issue would come from that library, not Teads.
>
> The cleanest long-term path remains upgrading the publisher's app compiler to Kotlin 2.x — at which point the flag becomes unnecessary for everyone.

### Why a per-module flag isn't enough in a real publisher project

A publisher reported that putting the snippet only in their app module's `build.gradle.kts` did **not** fix the build — they had to duplicate it across every module. That report is correct: in Gradle, `tasks.withType<KotlinCompile>().configureEach { … }` is **project-scoped**, so it only configures tasks in the module that declares it. Sibling library modules that also touch the Teads SDK keep failing.

This branch reproduces that exact situation by adding a small `:feature-foo` library module that consumes the Teads SDK, then proves a single root-level declaration (under `subprojects { }`) fixes every module at once.

## Solution

1. Pin the sample app's toolchain to Kotlin `1.9.24` to reproduce the publisher's setup end-to-end.
2. Downgrade the Compose stack so it remains compatible with Kotlin `1.9.24`:
   - Replace `org.jetbrains.kotlin.plugin.compose` (Kotlin 2.0+ only) with the legacy `composeOptions { kotlinCompilerExtensionVersion = "1.5.14" }` path.
   - Compose BOM `2025.09.01` → `2024.06.00` (the later BOMs expect Compose Compiler ≥ `1.5.15`, which only exists for Kotlin ≥ `2.0`).
3. **Make the demo multi-module.** Add `:feature-foo`, a tiny `com.android.library` that calls `TeadsSDK.configure(...)`, and depend on it from `:app`. With the flag declared only inside `:app/build.gradle.kts`, `:feature-foo:compileDebugKotlin` fails with the publisher's exact error — confirmed locally.
4. **Apply the flag project-wide from the root** instead of per-module:
   ```kotlin
   // TeadsSDKDemo/build.gradle.kts
   subprojects {
       tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
           kotlinOptions {
               freeCompilerArgs = freeCompilerArgs + "-Xskip-metadata-version-check"
           }
       }
   }
   ```
   The per-module block in `app/build.gradle.kts` is removed; both `:app` and `:feature-foo` build cleanly from this single declaration.
5. Document the rationale and copy-pasteable snippet in `KOTLIN_1.9.24_COMPAT_NOTES.md` at the repo root.

No `resolutionStrategy.force` on `kotlin-stdlib` is required — Gradle already resolves to the higher stdlib (`2.1.21`) pulled in by the Teads SDK, which is the correct outcome under the forward-compatibility rule.

### Alternative shapes (equivalent results)

- A `buildSrc` convention plugin that contains the same `tasks.withType<KotlinCompile>` block, applied to every module. Cleaner long-term if the project already uses convention plugins.
- `allprojects { … }` with the same body. Works, but Gradle is steering people away from `allprojects` because it breaks isolated-projects / future configuration-cache improvements; prefer `subprojects { }`.
- An init script or a `gradle.properties` flag — **not** recommended. Init scripts are invisible to other devs cloning the repo and easy to forget on CI; there is no official `gradle.properties` equivalent for `-Xskip-metadata-version-check`.

## Changes

| File | Change |
|------|--------|
| `KOTLIN_1.9.24_COMPAT_NOTES.md` | NEW - Branch-level README explaining the metadata-version problem and the single-flag workaround |
| `TeadsSDKDemo/buildSrc/build.gradle.kts` | MODIFIED - Kotlin Gradle Plugin `2.1.21` → `1.9.24`; removed `compose-compiler-gradle-plugin` (Kotlin 2.0+ only) |
| `TeadsSDKDemo/buildSrc/src/main/java/tv/teads/Versions.kt` | MODIFIED - `kotlin` `2.1.21` → `1.9.24`; `composeBom` `2025.09.01` → `2024.06.00`; added `composeCompiler = "1.5.14"` |
| `TeadsSDKDemo/build.gradle.kts` | MODIFIED - Added root-level `subprojects { }` block applying `-Xskip-metadata-version-check` to every submodule |
| `TeadsSDKDemo/settings.gradle.kts` | MODIFIED - Added `include(":feature-foo")` so the demo is genuinely multi-module |
| `TeadsSDKDemo/app/build.gradle.kts` | MODIFIED - Removed `org.jetbrains.kotlin.plugin.compose`; added `composeOptions { kotlinCompilerExtensionVersion = Versions.composeCompiler }` and `buildFeatures { compose = true }`; **removed** the per-module `-Xskip-metadata-version-check` block (now handled at root); added `implementation(project(":feature-foo"))` |
| `TeadsSDKDemo/feature-foo/build.gradle.kts` | NEW - Sibling library module consuming the Teads SDK; used to prove the multi-module fix works |
| `TeadsSDKDemo/feature-foo/src/main/AndroidManifest.xml` | NEW - Empty manifest for the new library module |
| `TeadsSDKDemo/feature-foo/src/main/java/tv/teads/featurefoo/FooTeadsCaller.kt` | NEW - Trivial consumer of `TeadsSDK.configure(...)` to force the metadata check on this module |

## Test Plan

- [x] Reproduced the publisher's failure: with the flag declared only in `:app/build.gradle.kts`, `:feature-foo:compileDebugKotlin` fails with `metadata version is 2.1.0, but the compiler version 1.9.0 can read versions up to 2.0.0` (verified locally)
- [x] Hoisted the flag into the root `build.gradle.kts` under `subprojects { }`, removed the per-module block from `:app`
- [x] `./gradlew :app:assembleDebug` → **BUILD SUCCESSFUL** (both `:app` and `:feature-foo` compile from a single declaration)
- [x] Kotlin compiler confirmed running as `1.9.24` (see `Versions.kotlin`)
- [x] App code still resolves Teads SDK public API (TeadsSDK, TeadsAdPlacement*, config classes, etc.) with the flag in place
- [ ] Publisher sanity-checks on their real app before production integration
- [ ] Delete this branch once the publisher confirms the workaround is integrated
