### PR TITLE
[Public Sample App] Upgrade to Teads SDK 6.2.0 (Anchored Banner + Recommendations URLConfig migration)

### DIFF
--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/data/DemoSessionConfiguration.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/data/DemoSessionConfiguration.kt
@@ -40,6 +40,11 @@ object DemoSessionConfiguration {
     const val DEFAULT_INTERSTITIAL_DIRECT_WIDGET_ID = "INT_MW_1"
     const val DEFAULT_INTERSTITIAL_DIRECT_ARTICLE_URL = "https://example.com/article"
 
+    // Banner uses Feed as its base (same Outbrain SFWebView engine + widget/installation/articleUrl shape)
+    const val DEFAULT_BANNER_DIRECT_WIDGET_ID = DEFAULT_FEED_WIDGET_ID
+    const val DEFAULT_BANNER_ADMOB_PID = "ca-app-pub-3068786746829754/5448863490"
+    const val DEFAULT_BANNER_ADMOB_TESTING_PID = "ca-app-pub-3940256099942544/9214589741"
+
     const val FAKE_TEADS_PREBID_TEST_SERVER =
         "https://tm3zwelt7nhxurh4rgapwm5smm0gywau.lambda-url.eu-west-1.on.aws/openrtb2/auction?verbose=true"
     const val PREBID_AD_CONFIG_ID = "imp-video-300x250"
@@ -101,6 +106,7 @@ object DemoSessionConfiguration {
             ProviderType.APPLOVIN  to FormatType.MEDIA -> DEFAULT_MEDIA_APPLOVIN_PID
             ProviderType.APPLOVIN  to FormatType.MEDIANATIVE -> DEFAULT_MEDIANATIVE_APPLOVIN_PID
             ProviderType.ADMOB to FormatType.INTERSTITIAL -> DEFAULT_INTERSTITIAL_ADMOB_PID
+            ProviderType.ADMOB to FormatType.BANNER -> DEFAULT_BANNER_ADMOB_PID
             else -> ""
         }
     }
@@ -117,6 +123,7 @@ object DemoSessionConfiguration {
             FormatType.FEED -> DEFAULT_FEED_WIDGET_ID
             FormatType.RECOMMENDATIONS -> DEFAULT_RECOMMENDATIONS_WIDGET_ID
             FormatType.INTERSTITIAL -> DEFAULT_INTERSTITIAL_DIRECT_WIDGET_ID
+            FormatType.BANNER -> DEFAULT_BANNER_DIRECT_WIDGET_ID
             else -> ""
         }
     }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/data/DemoSessionConfiguration.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/data/DemoSessionConfiguration.kt
@@ -41,7 +41,8 @@ object DemoSessionConfiguration {
     const val DEFAULT_INTERSTITIAL_DIRECT_ARTICLE_URL = "https://example.com/article"
 
     // Banner uses Feed as its base (same Outbrain SFWebView engine + widget/installation/articleUrl shape)
-    const val DEFAULT_BANNER_DIRECT_WIDGET_ID = DEFAULT_FEED_WIDGET_ID
+    // Widget id is banner-specific (matches DEFAULT_BANNER_WIDGET_ID in the internal combinedsdk-demo)
+    const val DEFAULT_BANNER_DIRECT_WIDGET_ID = "MB_10"
     const val DEFAULT_BANNER_ADMOB_PID = "ca-app-pub-3068786746829754/5448863490"
     const val DEFAULT_BANNER_ADMOB_TESTING_PID = "ca-app-pub-3940256099942544/9214589741"
 

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/domain/FormatType.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/domain/FormatType.kt
@@ -8,5 +8,6 @@ enum class FormatType(val displayName: String) {
     MEDIANATIVE("Media Native"),
     FEED("Feed"),
     RECOMMENDATIONS("Recommendations"),
-    INTERSTITIAL("Interstitial")
+    INTERSTITIAL("Interstitial"),
+    BANNER("Anchored Banner")
 }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/DemoViewModel.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/DemoViewModel.kt
@@ -187,6 +187,11 @@ class DemoViewModel : ViewModel() {
         "TEST_FEED" to "TEST_FEED"
     )
 
+    // Widget ID presets for Banner format
+    private val bannerWidgetIds = listOf(
+        "MB_10" to "MB_10"
+    )
+
     // Widget ID presets for Recommendations format
     private val recommendationsWidgetIds = listOf(
         "SDK_1" to "SDK_1",
@@ -198,6 +203,11 @@ class DemoViewModel : ViewModel() {
     private val feedInstallationKeys = listOf(
         "NANOWDGT01" to "NANOWDGT01",
         "TESTKEY01" to "TESTKEY01"
+    )
+
+    // Installation Key presets for Banner format
+    private val bannerInstallationKeys = listOf(
+        "NANOWDGT01" to "NANOWDGT01"
     )
 
     // Installation Key presets for Recommendations format
@@ -450,7 +460,7 @@ class DemoViewModel : ViewModel() {
         ProviderType.DIRECT to FormatType.FEED -> getFeedWidgetIdChips()
         ProviderType.DIRECT to FormatType.RECOMMENDATIONS -> getRecommendationsWidgetIdChips()
         ProviderType.DIRECT to FormatType.INTERSTITIAL -> emptyList()
-        ProviderType.DIRECT to FormatType.BANNER -> getFeedWidgetIdChips()
+        ProviderType.DIRECT to FormatType.BANNER -> getBannerWidgetIdChips()
         else -> throw IllegalAccessException("Impossible combination")
     }
 
@@ -567,6 +577,14 @@ class DemoViewModel : ViewModel() {
         )
     }
 
+    private fun getBannerWidgetIdChips(): List<ChipData> = bannerWidgetIds.mapIndexed { index, (label, _) ->
+        ChipData(
+            id = index,
+            text = label,
+            isSelected = _widgetId.value == bannerWidgetIds[index].second
+        )
+    }
+
     private fun getRecommendationsWidgetIdChips(): List<ChipData> = recommendationsWidgetIds.mapIndexed { index, (label, _) ->
         ChipData(
             id = index,
@@ -579,7 +597,7 @@ class DemoViewModel : ViewModel() {
         ProviderType.DIRECT to FormatType.FEED -> getFeedInstallationKeyChips()
         ProviderType.DIRECT to FormatType.RECOMMENDATIONS -> getRecommendationsInstallationKeyChips()
         ProviderType.DIRECT to FormatType.INTERSTITIAL -> emptyList()
-        ProviderType.DIRECT to FormatType.BANNER -> getFeedInstallationKeyChips()
+        ProviderType.DIRECT to FormatType.BANNER -> getBannerInstallationKeyChips()
         else -> throw IllegalAccessException("Impossible combination")
     }
 
@@ -588,6 +606,14 @@ class DemoViewModel : ViewModel() {
             id = index,
             text = label,
             isSelected = _installationKey.value == feedInstallationKeys[index].second
+        )
+    }
+
+    private fun getBannerInstallationKeyChips(): List<ChipData> = bannerInstallationKeys.mapIndexed { index, (label, _) ->
+        ChipData(
+            id = index,
+            text = label,
+            isSelected = _installationKey.value == bannerInstallationKeys[index].second
         )
     }
 
@@ -639,7 +665,7 @@ class DemoViewModel : ViewModel() {
     fun onWidgetChipClick(index: Int) = when (selectedProvider to selectedFormat) {
         ProviderType.DIRECT to FormatType.FEED -> onFeedWidgetIdChipClick(index)
         ProviderType.DIRECT to FormatType.RECOMMENDATIONS -> onRecommendationsWidgetIdChipClick(index)
-        ProviderType.DIRECT to FormatType.BANNER -> onFeedWidgetIdChipClick(index)
+        ProviderType.DIRECT to FormatType.BANNER -> onBannerWidgetIdChipClick(index)
         else -> throw IllegalAccessException("Impossible combination")
     }
 
@@ -707,6 +733,13 @@ class DemoViewModel : ViewModel() {
         }
     }
 
+    private fun onBannerWidgetIdChipClick(index: Int) {
+        if (index in bannerWidgetIds.indices) {
+            val widgetId = bannerWidgetIds[index].second
+            updateWidgetId(widgetId)
+        }
+    }
+
     private fun onRecommendationsWidgetIdChipClick(index: Int) {
         if (index in recommendationsWidgetIds.indices) {
             val widgetId = recommendationsWidgetIds[index].second
@@ -717,13 +750,20 @@ class DemoViewModel : ViewModel() {
     fun onInstallationKeyChipClick(index: Int) = when (selectedProvider to selectedFormat) {
         ProviderType.DIRECT to FormatType.FEED -> onFeedInstallationKeyChipClick(index)
         ProviderType.DIRECT to FormatType.RECOMMENDATIONS -> onRecommendationsInstallationKeyChipClick(index)
-        ProviderType.DIRECT to FormatType.BANNER -> onFeedInstallationKeyChipClick(index)
+        ProviderType.DIRECT to FormatType.BANNER -> onBannerInstallationKeyChipClick(index)
         else -> throw IllegalAccessException("Impossible combination")
     }
 
     private fun onFeedInstallationKeyChipClick(index: Int) {
         if (index in feedInstallationKeys.indices) {
             val installationKey = feedInstallationKeys[index].second
+            updateInstallationKey(installationKey)
+        }
+    }
+
+    private fun onBannerInstallationKeyChipClick(index: Int) {
+        if (index in bannerInstallationKeys.indices) {
+            val installationKey = bannerInstallationKeys[index].second
             updateInstallationKey(installationKey)
         }
     }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/DemoViewModel.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/DemoViewModel.kt
@@ -94,7 +94,8 @@ class DemoViewModel : ViewModel() {
         FormatType.MEDIANATIVE,
         FormatType.FEED,
         FormatType.RECOMMENDATIONS,
-        FormatType.INTERSTITIAL
+        FormatType.INTERSTITIAL,
+        FormatType.BANNER
     )
 
     // Provider types available for Media format
@@ -121,6 +122,12 @@ class DemoViewModel : ViewModel() {
 
     // Provider types available for Interstitial format
     private val interstitialProviders = listOf(
+        ProviderType.DIRECT,
+        ProviderType.ADMOB
+    )
+
+    // Provider types available for Banner format
+    private val bannerProviders = listOf(
         ProviderType.DIRECT,
         ProviderType.ADMOB
     )
@@ -165,6 +172,12 @@ class DemoViewModel : ViewModel() {
     private val interstitialAdmobPids = listOf(
         "Teads Ad" to DemoSessionConfiguration.DEFAULT_INTERSTITIAL_ADMOB_PID,
         "Google Test Ad" to DemoSessionConfiguration.DEFAULT_INTERSTITIAL_ADMOB_TESTING_PID
+    )
+
+    // PID presets for Banner AdMob format
+    private val bannerAdmobPids = listOf(
+        "Banner" to DemoSessionConfiguration.DEFAULT_BANNER_ADMOB_PID,
+        "Google Test Banner" to DemoSessionConfiguration.DEFAULT_BANNER_ADMOB_TESTING_PID
     )
 
     // Widget ID presets for Feed format
@@ -243,6 +256,7 @@ class DemoViewModel : ViewModel() {
             FormatType.MEDIANATIVE -> mediaNativeProviders
             FormatType.FEED, FormatType.RECOMMENDATIONS -> feedRecommendationsProviders
             FormatType.INTERSTITIAL -> interstitialProviders
+            FormatType.BANNER -> bannerProviders
             else -> throw IllegalAccessException("Impossible format")
         }
     }
@@ -319,6 +333,15 @@ class DemoViewModel : ViewModel() {
                 updateWidgetId(DemoSessionConfiguration.DEFAULT_INTERSTITIAL_DIRECT_WIDGET_ID)
                 updateInstallationKey(DemoSessionConfiguration.DEFAULT_INSTALLATION_KEY)
                 updateArticleUrl(DemoSessionConfiguration.DEFAULT_INTERSTITIAL_DIRECT_ARTICLE_URL)
+            }
+
+            ProviderType.ADMOB to FormatType.BANNER ->
+                updatePlacementId(DemoSessionConfiguration.DEFAULT_BANNER_ADMOB_PID)
+
+            ProviderType.DIRECT to FormatType.BANNER -> {
+                updateWidgetId(DemoSessionConfiguration.DEFAULT_BANNER_DIRECT_WIDGET_ID)
+                updateInstallationKey(DemoSessionConfiguration.DEFAULT_INSTALLATION_KEY)
+                updateArticleUrl(DemoSessionConfiguration.DEFAULT_ARTICLE_URL)
             }
         }
     }
@@ -398,11 +421,12 @@ class DemoViewModel : ViewModel() {
         return (listOf(ProviderType.DIRECT, ProviderType.ADMOB, ProviderType.APPLOVIN).contains(selectedProvider)
                 && listOf(FormatType.MEDIA, FormatType.MEDIANATIVE).contains(selectedFormat))
                 || (selectedProvider == ProviderType.ADMOB && selectedFormat == FormatType.INTERSTITIAL)
+                || (selectedProvider == ProviderType.ADMOB && selectedFormat == FormatType.BANNER)
     }
 
     fun hasWidgetId(): Boolean {
         return selectedProvider == ProviderType.DIRECT
-                && selectedFormat in listOf(FormatType.FEED, FormatType.RECOMMENDATIONS, FormatType.INTERSTITIAL)
+                && selectedFormat in listOf(FormatType.FEED, FormatType.RECOMMENDATIONS, FormatType.INTERSTITIAL, FormatType.BANNER)
     }
 
     fun getInputMethod(): KeyboardType = when (selectedProvider to selectedFormat) {
@@ -418,6 +442,7 @@ class DemoViewModel : ViewModel() {
         ProviderType.APPLOVIN to FormatType.MEDIA -> getMediaApplovinPidChips()
         ProviderType.APPLOVIN to FormatType.MEDIANATIVE -> getMediaNativeApplovinPidChips()
         ProviderType.ADMOB to FormatType.INTERSTITIAL -> getInterstitialAdmobPidChips()
+        ProviderType.ADMOB to FormatType.BANNER -> getBannerAdmobPidChips()
         else -> throw IllegalAccessException("Impossible combination")
     }
 
@@ -425,6 +450,7 @@ class DemoViewModel : ViewModel() {
         ProviderType.DIRECT to FormatType.FEED -> getFeedWidgetIdChips()
         ProviderType.DIRECT to FormatType.RECOMMENDATIONS -> getRecommendationsWidgetIdChips()
         ProviderType.DIRECT to FormatType.INTERSTITIAL -> emptyList()
+        ProviderType.DIRECT to FormatType.BANNER -> getFeedWidgetIdChips()
         else -> throw IllegalAccessException("Impossible combination")
     }
 
@@ -484,6 +510,14 @@ class DemoViewModel : ViewModel() {
         )
     }
 
+    private fun getBannerAdmobPidChips(): List<ChipData> = bannerAdmobPids.mapIndexed { index, (label, _) ->
+        ChipData(
+            id = index,
+            text = label,
+            isSelected = _placementId.value == bannerAdmobPids[index].second
+        )
+    }
+
     fun getIntegrationChips(): List<ChipData> {
         val integrationList = getFilteredIntegrationList()
 
@@ -504,6 +538,8 @@ class DemoViewModel : ViewModel() {
     private fun getFilteredIntegrationList(): List<IntegrationType> {
         return when {
             selectedFormat == FormatType.INTERSTITIAL -> singleColumnIntegrationType
+
+            selectedFormat == FormatType.BANNER -> singleColumnIntegrationType
 
             selectedProvider == ProviderType.DIRECT
                     && selectedFormat in listOf(FormatType.FEED, FormatType.MEDIA)
@@ -543,6 +579,7 @@ class DemoViewModel : ViewModel() {
         ProviderType.DIRECT to FormatType.FEED -> getFeedInstallationKeyChips()
         ProviderType.DIRECT to FormatType.RECOMMENDATIONS -> getRecommendationsInstallationKeyChips()
         ProviderType.DIRECT to FormatType.INTERSTITIAL -> emptyList()
+        ProviderType.DIRECT to FormatType.BANNER -> getFeedInstallationKeyChips()
         else -> throw IllegalAccessException("Impossible combination")
     }
 
@@ -595,12 +632,14 @@ class DemoViewModel : ViewModel() {
         ProviderType.APPLOVIN to FormatType.MEDIA -> onMediaApplovinPidChipClick(index)
         ProviderType.APPLOVIN to FormatType.MEDIANATIVE -> onMediaNativeApplovinPidChipClick(index)
         ProviderType.ADMOB to FormatType.INTERSTITIAL -> onInterstitialAdmobPidChipClick(index)
+        ProviderType.ADMOB to FormatType.BANNER -> onBannerAdmobPidChipClick(index)
         else -> throw IllegalAccessException("Impossible combination")
     }
 
     fun onWidgetChipClick(index: Int) = when (selectedProvider to selectedFormat) {
         ProviderType.DIRECT to FormatType.FEED -> onFeedWidgetIdChipClick(index)
         ProviderType.DIRECT to FormatType.RECOMMENDATIONS -> onRecommendationsWidgetIdChipClick(index)
+        ProviderType.DIRECT to FormatType.BANNER -> onFeedWidgetIdChipClick(index)
         else -> throw IllegalAccessException("Impossible combination")
     }
 
@@ -654,6 +693,13 @@ class DemoViewModel : ViewModel() {
         }
     }
 
+    private fun onBannerAdmobPidChipClick(index: Int) {
+        if (index in bannerAdmobPids.indices) {
+            val pid = bannerAdmobPids[index].second
+            updatePlacementId(pid)
+        }
+    }
+
     private fun onFeedWidgetIdChipClick(index: Int) {
         if (index in feedWidgetIds.indices) {
             val widgetId = feedWidgetIds[index].second
@@ -671,6 +717,7 @@ class DemoViewModel : ViewModel() {
     fun onInstallationKeyChipClick(index: Int) = when (selectedProvider to selectedFormat) {
         ProviderType.DIRECT to FormatType.FEED -> onFeedInstallationKeyChipClick(index)
         ProviderType.DIRECT to FormatType.RECOMMENDATIONS -> onRecommendationsInstallationKeyChipClick(index)
+        ProviderType.DIRECT to FormatType.BANNER -> onFeedInstallationKeyChipClick(index)
         else -> throw IllegalAccessException("Impossible combination")
     }
 

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/MainActivity.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/MainActivity.kt
@@ -258,12 +258,12 @@ class MainActivity : ComponentActivity() {
                         }
                         Route.BannerDirectColumn -> {
                             BannerDirectColumnScreen(
-                                modifier = Modifier.padding(paddingValues)
+                                contentPadding = paddingValues
                             )
                         }
                         Route.BannerAdMobColumn -> {
                             BannerAdmobColumnScreen(
-                                modifier = Modifier.padding(paddingValues)
+                                contentPadding = paddingValues
                             )
                         }
                         else -> {}

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/MainActivity.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/MainActivity.kt
@@ -31,6 +31,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import tv.teads.teadssdkdemo.v6.ui.base.navigation.NavigationHandler
 import tv.teads.teadssdkdemo.v6.ui.base.navigation.Route
 import tv.teads.teadssdkdemo.v6.ui.base.theme.TeadsSDKDemoTheme
+import tv.teads.teadssdkdemo.v6.ui.compose.BannerAdmobColumnScreen
+import tv.teads.teadssdkdemo.v6.ui.compose.BannerDirectColumnScreen
 import tv.teads.teadssdkdemo.v6.ui.compose.InterstitialAdmobColumnScreen
 import tv.teads.teadssdkdemo.v6.ui.compose.InterstitialDirectColumnScreen
 import tv.teads.teadssdkdemo.v6.ui.compose.FeedColumnScreen
@@ -96,6 +98,8 @@ class MainActivity : ComponentActivity() {
                                         Route.RecommendationsLazyColumn -> "Recommendations LazyColumn"
                                         Route.InterstitialAdMobColumn -> "Interstitial AdMob Column"
                                         Route.InterstitialDirectColumn -> "Interstitial Direct Column"
+                                        Route.BannerDirectColumn -> "Banner Direct Column"
+                                        Route.BannerAdMobColumn -> "Banner AdMob Column"
                                         else -> "Teads SDK Demo"
                                     },
                                     style = MaterialTheme.typography.titleLarge.copy(
@@ -118,7 +122,8 @@ class MainActivity : ComponentActivity() {
                                     Route.MediaSmartColumn, Route.MediaNativeSmartColumn,
                                     Route.FeedColumn, Route.FeedLazyColumn,
                                     Route.RecommendationsColumn, Route.RecommendationsLazyColumn,
-                                    Route.InterstitialAdMobColumn, Route.InterstitialDirectColumn -> {
+                                    Route.InterstitialAdMobColumn, Route.InterstitialDirectColumn,
+                                    Route.BannerDirectColumn, Route.BannerAdMobColumn -> {
                                         IconButton(onClick = { currentRoute = Route.Demo }) {
                                             Icon(
                                                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -146,7 +151,8 @@ class MainActivity : ComponentActivity() {
                                     Route.MediaSmartColumn, Route.MediaNativeSmartColumn,
                                     Route.FeedColumn, Route.FeedLazyColumn,
                                     Route.RecommendationsColumn, Route.RecommendationsLazyColumn,
-                                    Route.InterstitialAdMobColumn, Route.InterstitialDirectColumn -> {
+                                    Route.InterstitialAdMobColumn, Route.InterstitialDirectColumn,
+                                    Route.BannerDirectColumn, Route.BannerAdMobColumn -> {
                                         currentRoute = navRoute
                                     }
                                     else -> {
@@ -248,6 +254,16 @@ class MainActivity : ComponentActivity() {
                             InterstitialDirectColumnScreen(
                                 modifier = Modifier.padding(paddingValues),
                                 activity = this@MainActivity
+                            )
+                        }
+                        Route.BannerDirectColumn -> {
+                            BannerDirectColumnScreen(
+                                modifier = Modifier.padding(paddingValues)
+                            )
+                        }
+                        Route.BannerAdMobColumn -> {
+                            BannerAdmobColumnScreen(
+                                modifier = Modifier.padding(paddingValues)
                             )
                         }
                         else -> {}

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/components/FormatDescription.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/components/FormatDescription.kt
@@ -25,6 +25,7 @@ fun FormatDescription(
         FormatType.FEED -> "— Content Discovery Feed — A recommendation grid of articles or videos (\"You might also like\"). Drives engagement via contextual relevance."
         FormatType.RECOMMENDATIONS -> "— A native grid of sponsored and organic stories (\"You might also like\") that blends with the publisher's content layout. Drives engagement by fitting contextually and visually into the reading experience."
         FormatType.INTERSTITIAL -> "— Full-screen ad that covers the host app interface. Shown at natural transition points to unlock premium content."
+        FormatType.BANNER -> "— Anchored adaptive banner pinned to the top or bottom of the screen. Sizing is owned by the SDK; the host container should be wrap_content."
         null -> ""
     }
 

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/navigation/Routes.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/base/navigation/Routes.kt
@@ -62,6 +62,8 @@ sealed class Route {
     data object RecommendationsLazyColumn : Route()
     data object InterstitialAdMobColumn : Route()
     data object InterstitialDirectColumn : Route()
+    data object BannerDirectColumn : Route()
+    data object BannerAdMobColumn : Route()
 }
 
 /**
@@ -186,6 +188,18 @@ object RouteFactory {
                     else -> throw IllegalAccessException("Impossible route")
                 }
             }
+            format == FormatType.BANNER && provider == ProviderType.DIRECT -> {
+                when (integration) {
+                    IntegrationType.COLUMN -> Route.BannerDirectColumn
+                    else -> throw IllegalAccessException("Impossible route")
+                }
+            }
+            format == FormatType.BANNER && provider == ProviderType.ADMOB -> {
+                when (integration) {
+                    IntegrationType.COLUMN -> Route.BannerAdMobColumn
+                    else -> throw IllegalAccessException("Impossible route")
+                }
+            }
             else -> throw IllegalAccessException("Impossible route")
         }
     }
@@ -284,5 +298,7 @@ fun Route.getTitle(): String {
         Route.MediaAdMobScrollView -> "Media AdMob ScrollView"
         Route.InterstitialAdMobColumn -> "Interstitial AdMob Column"
         Route.InterstitialDirectColumn -> "Interstitial Direct Column"
+        Route.BannerDirectColumn -> "Banner Direct Column"
+        Route.BannerAdMobColumn -> "Banner AdMob Column"
     }
 }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerAdmobColumnScreen.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerAdmobColumnScreen.kt
@@ -51,17 +51,12 @@ fun BannerAdmobColumnScreen(
         //    so the publisher integration is just a bare AdView)
         MobileAds.initialize(context)
 
-        // 2. Create AdMob view and configure it as an anchored adaptive banner
+        // 2. Create AdMob view and configure it with a fixed banner size
         val admobAdView = AdView(context)
         admobAdView.adUnitId = DemoSessionConfiguration.getPlacementIdOrDefault() // Your unique ad unit id
 
-        // Use anchored adaptive banner sizing — the Teads JS engine reports its
-        // own dynamic height via HEIGHT_UPDATED, so the host container view should
-        // be wrap_content to accommodate the reported size.
-        val widthDp = context.resources.configuration.screenWidthDp
-        admobAdView.setAdSize(
-            AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, widthDp)
-        )
+        // Request a fixed AdSize.BANNER (320x50dp) from the AdMob waterfall.
+        admobAdView.setAdSize(AdSize.BANNER)
 
         // 3. Listen to lifecycle events
         admobAdView.adListener = object : AdListener() {

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerAdmobColumnScreen.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerAdmobColumnScreen.kt
@@ -3,9 +3,13 @@ package tv.teads.teadssdkdemo.v6.ui.compose
 import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -16,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.viewinterop.AndroidView
 import com.google.android.gms.ads.AdListener
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
@@ -24,7 +29,6 @@ import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.MobileAds
 import tv.teads.teadssdkdemo.R
 import tv.teads.teadssdkdemo.v6.data.DemoSessionConfiguration
-import tv.teads.teadssdkdemo.v6.ui.base.components.AdContainer
 import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleBody
 import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleLabel
 import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleSpacing
@@ -34,7 +38,8 @@ private const val TAG = "BannerAdmobColumn"
 
 @Composable
 fun BannerAdmobColumnScreen(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues()
 ) {
     val context = LocalContext.current
     var adView by remember { mutableStateOf<AdView?>(null) }
@@ -93,27 +98,41 @@ fun BannerAdmobColumnScreen(
         }
     }
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.Top,
-    ) {
-        ArticleLabel()
-        ArticleSpacing()
-        ArticleTitle()
-        ArticleSpacing()
-        ArticleBody(text = stringResource(R.string.article_template_body_a))
-        ArticleSpacing()
-        ArticleBody(text = stringResource(R.string.article_template_body_b))
-        ArticleSpacing()
-
-        // 6. Add the anchored banner container
-        AdContainer(adView = adView)
-
-        ArticleSpacing()
-        ArticleBody(text = stringResource(R.string.article_template_body_c))
-        ArticleSpacing()
-        ArticleBody(text = stringResource(R.string.article_template_body_d))
+    // 6. Render the article in a Scaffold whose bottomBar pins the banner to the
+    //    bottom of the screen (mirrors the combinedsdk-demo Column use case).
+    //    No topBar — the parent activity already supplies one.
+    Scaffold(
+        modifier = modifier,
+        bottomBar = {
+            adView?.let { view ->
+                AndroidView(
+                    factory = { view },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    ) { scaffoldPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = contentPadding.calculateTopPadding())
+                .padding(bottom = scaffoldPadding.calculateBottomPadding())
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.Top,
+        ) {
+            ArticleLabel()
+            ArticleSpacing()
+            ArticleTitle()
+            ArticleSpacing()
+            ArticleBody(text = stringResource(R.string.article_template_body_a))
+            ArticleSpacing()
+            ArticleBody(text = stringResource(R.string.article_template_body_b))
+            ArticleSpacing()
+            ArticleBody(text = stringResource(R.string.article_template_body_c))
+            ArticleSpacing()
+            ArticleBody(text = stringResource(R.string.article_template_body_d))
+            ArticleSpacing()
+            ArticleBody(text = stringResource(R.string.article_template_body_e))
+        }
     }
 }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerAdmobColumnScreen.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerAdmobColumnScreen.kt
@@ -1,0 +1,119 @@
+package tv.teads.teadssdkdemo.v6.ui.compose
+
+import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import com.google.android.gms.ads.AdListener
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.MobileAds
+import tv.teads.teadssdkdemo.R
+import tv.teads.teadssdkdemo.v6.data.DemoSessionConfiguration
+import tv.teads.teadssdkdemo.v6.ui.base.components.AdContainer
+import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleBody
+import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleLabel
+import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleSpacing
+import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleTitle
+
+private const val TAG = "BannerAdmobColumn"
+
+@Composable
+fun BannerAdmobColumnScreen(
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    var adView by remember { mutableStateOf<AdView?>(null) }
+
+    LaunchedEffect(Unit) {
+        // 1. Initialize AdMob (the Banner adapter on the AdMob server returns a
+        //    Teads anchored placement; events are routed internally by the adapter,
+        //    so the publisher integration is just a bare AdView)
+        MobileAds.initialize(context)
+
+        // 2. Create AdMob view and configure it as an anchored adaptive banner
+        val admobAdView = AdView(context)
+        admobAdView.adUnitId = DemoSessionConfiguration.getPlacementIdOrDefault() // Your unique ad unit id
+
+        // Use anchored adaptive banner sizing — the Teads JS engine reports its
+        // own dynamic height via HEIGHT_UPDATED, so the host container view should
+        // be wrap_content to accommodate the reported size.
+        val widthDp = context.resources.configuration.screenWidthDp
+        admobAdView.setAdSize(
+            AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, widthDp)
+        )
+
+        // 3. Listen to lifecycle events
+        admobAdView.adListener = object : AdListener() {
+            override fun onAdImpression() {
+                Log.d(TAG, "onAdImpression")
+            }
+            override fun onAdClicked() {
+                Log.d(TAG, "onAdClicked")
+            }
+            override fun onAdFailedToLoad(error: LoadAdError) {
+                Log.e(TAG, "onAdFailedToLoad: ${error.cause?.message}")
+            }
+            override fun onAdLoaded() {
+                Log.d(TAG, "onAdLoaded")
+            }
+            override fun onAdOpened() {
+                Log.d(TAG, "onAdOpened")
+            }
+            override fun onAdClosed() {
+                Log.d(TAG, "onAdClosed")
+            }
+        }
+
+        // 4. Load the ad
+        admobAdView.loadAd(AdRequest.Builder().build())
+
+        adView = admobAdView
+    }
+
+    // Cleanup when composable is disposed
+    DisposableEffect(Unit) {
+        onDispose {
+            // 5. Clean up resources
+            adView?.destroy()
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.Top,
+    ) {
+        ArticleLabel()
+        ArticleSpacing()
+        ArticleTitle()
+        ArticleSpacing()
+        ArticleBody(text = stringResource(R.string.article_template_body_a))
+        ArticleSpacing()
+        ArticleBody(text = stringResource(R.string.article_template_body_b))
+        ArticleSpacing()
+
+        // 6. Add the anchored banner container
+        AdContainer(adView = adView)
+
+        ArticleSpacing()
+        ArticleBody(text = stringResource(R.string.article_template_body_c))
+        ArticleSpacing()
+        ArticleBody(text = stringResource(R.string.article_template_body_d))
+    }
+}

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerAdmobColumnScreen.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerAdmobColumnScreen.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -103,11 +104,14 @@ fun BannerAdmobColumnScreen(
     //    No topBar — the parent activity already supplies one.
     Scaffold(
         modifier = modifier,
+        contentWindowInsets = WindowInsets(0),
         bottomBar = {
             adView?.let { view ->
                 AndroidView(
                     factory = { view },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = contentPadding.calculateBottomPadding())
                 )
             }
         }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerDirectColumnScreen.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerDirectColumnScreen.kt
@@ -1,0 +1,126 @@
+package tv.teads.teadssdkdemo.v6.ui.compose
+
+import android.util.Log
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.core.net.toUri
+import tv.teads.sdk.TeadsSDK
+import tv.teads.sdk.combinedsdk.TeadsAdPlacementEventName
+import tv.teads.sdk.combinedsdk.adplacement.TeadsAdPlacementBanner
+import tv.teads.sdk.combinedsdk.adplacement.config.TeadsAdPlacementBannerConfig
+import tv.teads.sdk.combinedsdk.adplacement.interfaces.TeadsAdPlacementEventsDelegate
+import tv.teads.sdk.combinedsdk.adplacement.interfaces.core.TeadsAdPlacement
+import tv.teads.teadssdkdemo.BuildConfig
+import tv.teads.teadssdkdemo.R
+import tv.teads.teadssdkdemo.v6.data.DemoSessionConfiguration
+import tv.teads.teadssdkdemo.v6.ui.base.components.AdContainer
+import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleBody
+import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleLabel
+import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleSpacing
+import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleTitle
+import tv.teads.teadssdkdemo.v6.utils.BrowserNavigationHelper
+
+private const val TAG = "BannerDirectColumn"
+
+@Composable
+fun BannerDirectColumnScreen(
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    var adView by remember { mutableStateOf<ViewGroup?>(null) }
+    var bannerAd by remember { mutableStateOf<TeadsAdPlacementBanner?>(null) }
+
+    LaunchedEffect(Unit) {
+        // 0. Init SDK
+        initTeadsSDK(context)
+
+        // 1. Init configuration
+        val config = TeadsAdPlacementBannerConfig(
+            articleUrl = DemoSessionConfiguration.getArticleUrlOrDefault().toUri(), // Your article url
+            widgetId = DemoSessionConfiguration.getWidgetIdOrDefault(), // Your unique widget id
+            installationKey = DemoSessionConfiguration.getInstallationKeyOrDefault(), // Your unique installation key
+            widgetIndex = 0 // Position of the ad within your article. Increment by 1 for each additional ad on the same page
+        )
+
+        // 2. Create placement
+        bannerAd = TeadsAdPlacementBanner(
+            context = context,
+            config = config,
+            delegate = object : TeadsAdPlacementEventsDelegate {
+                override fun onPlacementEvent(
+                    placement: TeadsAdPlacement<*, *>,
+                    event: TeadsAdPlacementEventName,
+                    data: Map<String, Any>?
+                ) {
+                    // 4. Stay tuned to lifecycle events
+                    Log.d(TAG, "$placement - $event: $data")
+
+                    if (event == TeadsAdPlacementEventName.CLICKED_ORGANIC) {
+                        val url = data?.get("url") as? String
+                        url?.let {
+                            BrowserNavigationHelper.openInnerBrowser(context, it)
+                        }
+                    }
+                }
+            }
+        )
+
+        // 3. Request ad — anchored banner sizing is owned by the JS engine,
+        //    container should be wrap_content (height reported via HEIGHT_UPDATED)
+        adView = bannerAd?.loadAd()
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.Top,
+    ) {
+        ArticleLabel()
+        ArticleSpacing()
+        ArticleTitle()
+        ArticleSpacing()
+        ArticleBody(text = stringResource(R.string.article_template_body_a))
+        ArticleSpacing()
+        ArticleBody(text = stringResource(R.string.article_template_body_b))
+        ArticleSpacing()
+
+        // 5. Add the anchored banner container
+        AdContainer(adView = adView)
+
+        ArticleSpacing()
+        ArticleBody(text = stringResource(R.string.article_template_body_c))
+        ArticleSpacing()
+        ArticleBody(text = stringResource(R.string.article_template_body_d))
+    }
+}
+
+/**
+ * Initialize TeadsSDK - can be init once on the start of the app
+ */
+private fun initTeadsSDK(context: android.content.Context) {
+    // Mandatory for placements [Feed, Recommendations, Banner]
+    TeadsSDK.configure(
+        applicationContext = context.applicationContext,
+        appKey = "AndroidSampleApp2014" // Your unique application key
+    )
+
+    // For testing purposes
+    if (BuildConfig.DEBUG) {
+        TeadsSDK.testMode = true // Enable more logging visibility
+        TeadsSDK.testLocation = "us" // Emulates location for placements [Feed, Recommendations, Banner]
+    }
+}

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerDirectColumnScreen.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerDirectColumnScreen.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -93,11 +94,14 @@ fun BannerDirectColumnScreen(
     //    No topBar — the parent activity already supplies one.
     Scaffold(
         modifier = modifier,
+        contentWindowInsets = WindowInsets(0),
         bottomBar = {
             adView?.let { view ->
                 AndroidView(
                     factory = { view },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = contentPadding.calculateBottomPadding())
                 )
             }
         }

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerDirectColumnScreen.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerDirectColumnScreen.kt
@@ -4,9 +4,13 @@ import android.util.Log
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -16,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.net.toUri
 import tv.teads.sdk.TeadsSDK
 import tv.teads.sdk.combinedsdk.TeadsAdPlacementEventName
@@ -26,7 +31,6 @@ import tv.teads.sdk.combinedsdk.adplacement.interfaces.core.TeadsAdPlacement
 import tv.teads.teadssdkdemo.BuildConfig
 import tv.teads.teadssdkdemo.R
 import tv.teads.teadssdkdemo.v6.data.DemoSessionConfiguration
-import tv.teads.teadssdkdemo.v6.ui.base.components.AdContainer
 import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleBody
 import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleLabel
 import tv.teads.teadssdkdemo.v6.ui.base.components.ArticleSpacing
@@ -37,7 +41,8 @@ private const val TAG = "BannerDirectColumn"
 
 @Composable
 fun BannerDirectColumnScreen(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues()
 ) {
     val context = LocalContext.current
     var adView by remember { mutableStateOf<ViewGroup?>(null) }
@@ -50,7 +55,7 @@ fun BannerDirectColumnScreen(
         // 1. Init configuration
         val config = TeadsAdPlacementBannerConfig(
             articleUrl = DemoSessionConfiguration.getArticleUrlOrDefault().toUri(), // Your article url
-            widgetId = DemoSessionConfiguration.getWidgetIdOrDefault(), // Your unique widget id
+            widgetId = DemoSessionConfiguration.getWidgetIdOrDefault(), // Your unique banner widget id
             installationKey = DemoSessionConfiguration.getInstallationKeyOrDefault(), // Your unique installation key
             widgetIndex = 0 // Position of the ad within your article. Increment by 1 for each additional ad on the same page
         )
@@ -83,28 +88,42 @@ fun BannerDirectColumnScreen(
         adView = bannerAd?.loadAd()
     }
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.Top,
-    ) {
-        ArticleLabel()
-        ArticleSpacing()
-        ArticleTitle()
-        ArticleSpacing()
-        ArticleBody(text = stringResource(R.string.article_template_body_a))
-        ArticleSpacing()
-        ArticleBody(text = stringResource(R.string.article_template_body_b))
-        ArticleSpacing()
-
-        // 5. Add the anchored banner container
-        AdContainer(adView = adView)
-
-        ArticleSpacing()
-        ArticleBody(text = stringResource(R.string.article_template_body_c))
-        ArticleSpacing()
-        ArticleBody(text = stringResource(R.string.article_template_body_d))
+    // 5. Render the article in a Scaffold whose bottomBar pins the banner to the
+    //    bottom of the screen (mirrors the combinedsdk-demo Column use case).
+    //    No topBar — the parent activity already supplies one.
+    Scaffold(
+        modifier = modifier,
+        bottomBar = {
+            adView?.let { view ->
+                AndroidView(
+                    factory = { view },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    ) { scaffoldPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = contentPadding.calculateTopPadding())
+                .padding(bottom = scaffoldPadding.calculateBottomPadding())
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.Top,
+        ) {
+            ArticleLabel()
+            ArticleSpacing()
+            ArticleTitle()
+            ArticleSpacing()
+            ArticleBody(text = stringResource(R.string.article_template_body_a))
+            ArticleSpacing()
+            ArticleBody(text = stringResource(R.string.article_template_body_b))
+            ArticleSpacing()
+            ArticleBody(text = stringResource(R.string.article_template_body_c))
+            ArticleSpacing()
+            ArticleBody(text = stringResource(R.string.article_template_body_d))
+            ArticleSpacing()
+            ArticleBody(text = stringResource(R.string.article_template_body_e))
+        }
     }
 }
 

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/RecommendationsColumnScreen.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/RecommendationsColumnScreen.kt
@@ -20,6 +20,7 @@ import tv.teads.sdk.TeadsSDK
 import tv.teads.sdk.combinedsdk.TeadsAdPlacementEventName
 import tv.teads.sdk.combinedsdk.adplacement.TeadsAdPlacementRecommendations
 import tv.teads.sdk.combinedsdk.adplacement.config.TeadsAdPlacementRecommendationsConfig
+import tv.teads.sdk.combinedsdk.adplacement.config.TeadsAdPlacementRecommendationsURLConfig
 import tv.teads.sdk.combinedsdk.adplacement.interfaces.TeadsAdPlacementEventsDelegate
 import tv.teads.sdk.combinedsdk.adplacement.interfaces.core.TeadsAdPlacement
 import tv.teads.teadssdkdemo.BuildConfig
@@ -45,9 +46,10 @@ fun RecommendationsColumnScreen(
         initTeadsSDK(context)
         
         // 1. Init configuration
+        val articleUrl = DemoSessionConfiguration.getArticleUrlOrDefault().toUri() // Your article url
         val config = TeadsAdPlacementRecommendationsConfig(
-            articleUrl = DemoSessionConfiguration.getArticleUrlOrDefault().toUri(), // Your article url
-            widgetId = DemoSessionConfiguration.getWidgetIdOrDefault() // Your widget id
+            widgetId = DemoSessionConfiguration.getWidgetIdOrDefault(), // Your widget id
+            urlConfig = TeadsAdPlacementRecommendationsURLConfig(articleUrl = articleUrl)
         )
 
         // 2. Create placement
@@ -73,7 +75,7 @@ fun RecommendationsColumnScreen(
             val response = recommendationsAd!!.loadAdSuspend()
             recommendationsAdView!!.bind(
                 recommendations = response,
-                articleUrl = config.articleUrl
+                articleUrl = articleUrl
             )
         } catch (e: Exception) {
             Log.e("RecommendationsColumnScreen", "Recommendations failed to load", e)

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/RecommendationsLazyColumnScreen.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/RecommendationsLazyColumnScreen.kt
@@ -17,6 +17,7 @@ import tv.teads.sdk.TeadsSDK
 import tv.teads.sdk.combinedsdk.TeadsAdPlacementEventName
 import tv.teads.sdk.combinedsdk.adplacement.TeadsAdPlacementRecommendations
 import tv.teads.sdk.combinedsdk.adplacement.config.TeadsAdPlacementRecommendationsConfig
+import tv.teads.sdk.combinedsdk.adplacement.config.TeadsAdPlacementRecommendationsURLConfig
 import tv.teads.sdk.combinedsdk.adplacement.interfaces.TeadsAdPlacementEventsDelegate
 import tv.teads.sdk.combinedsdk.adplacement.interfaces.core.TeadsAdPlacement
 import tv.teads.teadssdkdemo.BuildConfig
@@ -42,9 +43,10 @@ fun RecommendationsLazyColumnScreen(
         initTeadsSDK(context)
         
         // 1. Init configuration
+        val articleUrl = DemoSessionConfiguration.getArticleUrlOrDefault().toUri() // Your article url
         val config = TeadsAdPlacementRecommendationsConfig(
-            articleUrl = DemoSessionConfiguration.getArticleUrlOrDefault().toUri(), // Your article url
-            widgetId = DemoSessionConfiguration.getWidgetIdOrDefault() // Your widget id
+            widgetId = DemoSessionConfiguration.getWidgetIdOrDefault(), // Your widget id
+            urlConfig = TeadsAdPlacementRecommendationsURLConfig(articleUrl = articleUrl)
         )
 
         // 2. Create placement
@@ -70,7 +72,7 @@ fun RecommendationsLazyColumnScreen(
             val response = recommendationsAd!!.loadAdSuspend()
             recommendationsAdView!!.bind(
                 recommendations = response,
-                articleUrl = config.articleUrl
+                articleUrl = articleUrl
             )
         } catch (e: Exception) {
             Log.e("RecommendationsLazyColumnScreen", "Recommendations failed to load", e)

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/xml/RecommendationsRecyclerViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/xml/RecommendationsRecyclerViewFragment.kt
@@ -1,5 +1,6 @@
 package tv.teads.teadssdkdemo.v6.ui.xml
 
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -20,6 +21,7 @@ import tv.teads.sdk.TeadsSDK
 import tv.teads.sdk.combinedsdk.TeadsAdPlacementEventName
 import tv.teads.sdk.combinedsdk.adplacement.TeadsAdPlacementRecommendations
 import tv.teads.sdk.combinedsdk.adplacement.config.TeadsAdPlacementRecommendationsConfig
+import tv.teads.sdk.combinedsdk.adplacement.config.TeadsAdPlacementRecommendationsURLConfig
 import tv.teads.sdk.combinedsdk.adplacement.interfaces.TeadsAdPlacementEventsDelegate
 import tv.teads.sdk.combinedsdk.adplacement.interfaces.core.TeadsAdPlacement
 import tv.teads.teadssdkdemo.BuildConfig
@@ -30,6 +32,8 @@ import tv.teads.teadssdkdemo.v6.ui.base.recommendations.RecommendationsAdView
 class RecommendationsRecyclerViewFragment : Fragment(), TeadsAdPlacementEventsDelegate {
 
     private lateinit var recommendationsAd: TeadsAdPlacementRecommendations
+    private lateinit var articleUrl: Uri
+
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -45,9 +49,10 @@ class RecommendationsRecyclerViewFragment : Fragment(), TeadsAdPlacementEventsDe
         initTeadsSDK()
 
         // 1. Init configuration
+        articleUrl = DemoSessionConfiguration.getArticleUrlOrDefault().toUri() // Your article url
         val config = TeadsAdPlacementRecommendationsConfig(
-            articleUrl = DemoSessionConfiguration.getArticleUrlOrDefault().toUri(), // Your article url
-            widgetId = DemoSessionConfiguration.getWidgetIdOrDefault() // Your widget id
+            widgetId = DemoSessionConfiguration.getWidgetIdOrDefault(), // Your widget id
+            urlConfig = TeadsAdPlacementRecommendationsURLConfig(articleUrl = articleUrl)
         )
 
         // 2. Create placement
@@ -62,7 +67,7 @@ class RecommendationsRecyclerViewFragment : Fragment(), TeadsAdPlacementEventsDe
     private fun setupRecyclerViewContent(view: View) {
         val recyclerView = RecyclerView(requireContext()).apply {
             layoutManager = LinearLayoutManager(requireContext())
-            adapter = ArticleRecyclerViewAdapter(recommendationsAd)
+            adapter = ArticleRecyclerViewAdapter(recommendationsAd, articleUrl)
         }
 
         view.findViewById<LinearLayout>(R.id.content_container)?.apply {
@@ -98,6 +103,7 @@ class RecommendationsRecyclerViewFragment : Fragment(), TeadsAdPlacementEventsDe
 
     class ArticleRecyclerViewAdapter(
         private val recommendationsAd: TeadsAdPlacementRecommendations,
+        private val articleUrl: Uri,
     ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
         // ViewHolder for article image
@@ -191,7 +197,7 @@ class RecommendationsRecyclerViewFragment : Fragment(), TeadsAdPlacementEventsDe
                     val response = recommendationsAd.loadAdSuspend()
                     recommendationsAdView.bind(
                         recommendations = response,
-                        articleUrl = recommendationsAd.config.articleUrl
+                        articleUrl = articleUrl
                     )
                 } catch (e: Exception) {
                     Log.e("RecommendationsRecyclerViewFragment", "Recommendations failed to load", e)

--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/xml/RecommendationsScrollViewFragment.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/xml/RecommendationsScrollViewFragment.kt
@@ -13,6 +13,7 @@ import tv.teads.sdk.TeadsSDK
 import tv.teads.sdk.combinedsdk.TeadsAdPlacementEventName
 import tv.teads.sdk.combinedsdk.adplacement.TeadsAdPlacementRecommendations
 import tv.teads.sdk.combinedsdk.adplacement.config.TeadsAdPlacementRecommendationsConfig
+import tv.teads.sdk.combinedsdk.adplacement.config.TeadsAdPlacementRecommendationsURLConfig
 import tv.teads.sdk.combinedsdk.adplacement.interfaces.TeadsAdPlacementEventsDelegate
 import tv.teads.sdk.combinedsdk.adplacement.interfaces.core.TeadsAdPlacement
 import tv.teads.teadssdkdemo.BuildConfig
@@ -51,9 +52,10 @@ class RecommendationsScrollViewFragment : Fragment(), TeadsAdPlacementEventsDele
         adContainer.addView(recommendationsAdView)
 
         // 3. Init configuration
+        val articleUrl = DemoSessionConfiguration.getArticleUrlOrDefault().toUri() // Your article url
         val config = TeadsAdPlacementRecommendationsConfig(
-            articleUrl = DemoSessionConfiguration.getArticleUrlOrDefault().toUri(), // Your article url
-            widgetId = DemoSessionConfiguration.getWidgetIdOrDefault() // Your widget id
+            widgetId = DemoSessionConfiguration.getWidgetIdOrDefault(), // Your widget id
+            urlConfig = TeadsAdPlacementRecommendationsURLConfig(articleUrl = articleUrl)
         )
 
         // 4. Create placement
@@ -68,7 +70,7 @@ class RecommendationsScrollViewFragment : Fragment(), TeadsAdPlacementEventsDele
                 val response = recommendationsAd.loadAdSuspend()
                 recommendationsAdView.bind(
                     recommendations = response,
-                    articleUrl = config.articleUrl
+                    articleUrl = articleUrl
                 )
             } catch (e: Exception) {
                 Log.e("RecommendationsScrollViewFragment", "Recommendations failed to load", e)

--- a/TeadsSDKDemo/gradle.properties
+++ b/TeadsSDKDemo/gradle.properties
@@ -27,5 +27,5 @@ org.gradle.caching=true
 org.gradle.vfs.watch=true
 
 # Project version information
-VERSION_NAME=6.1.0
-VERSION_CODE=143
+VERSION_NAME=6.2.0
+VERSION_CODE=144

--- a/TeadsSDKDemo/settings.gradle.kts
+++ b/TeadsSDKDemo/settings.gradle.kts
@@ -13,6 +13,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven(url = "https://teads.jfrog.io/artifactory/SDKAndroid-maven-prod")
+        maven(url = "https://teads.jfrog.io/artifactory/SDKAndroid-maven-earlyAccess")
         maven(url = "https://s3.amazonaws.com/moat-sdk-builds")
 
         //Huawei maven repository


### PR DESCRIPTION
## Summary

Upgrades the public demo app to **Teads SDK 6.2.0** and adopts the new public API that release ships. Two parts:

1. **New Anchored Banner format sample** (Direct + AdMob), exposing the new `TeadsAdPlacementBanner` Combined SDK API (ART-596).
2. **Recommendations migration** to the new `TeadsAdPlacementRecommendationsURLConfig` constructor — the prior `TeadsAdPlacementRecommendationsConfig(articleUrl, …)` shape is **deprecated** in 6.2.0.

## Problem

- 6.2.0 introduces `TeadsAdPlacementBanner` (anchored adaptive banner, Outbrain SFWebView), but the public demo app had no copy-pasteable integration sample for either the Direct or AdMob mediation path.
- 6.2.0 also **deprecated** the Recommendations config constructor in favour of a `urlConfig` (and `platformConfig`) variant. The existing Recommendations samples still called the deprecated path, so the public app was demonstrating an outdated integration.

## Solution

1. **Bumped SDK to 6.2.0** (`VERSION_NAME=6.2.0`, `VERSION_CODE=144`) and added the JFrog `SDKAndroid-maven-earlyAccess` repository.
2. **Added `FormatType.BANNER` ("Anchored Banner")** wired through the existing Format / Provider / Placement / Integration flow used for Feed and Interstitial.
3. **Two new Banner Column screens:**
   - `BannerDirectColumnScreen` — builds `TeadsAdPlacementBannerConfig` from the session config (widgetId, installationKey, articleUrl, widgetIndex=0), renders the returned View.
   - `BannerAdmobColumnScreen` — bare `AdView` with anchored adaptive sizing; the AdMob `TeadsBannerAdapter` routes events internally.
4. **Migrated all four Recommendations samples** (Column, LazyColumn, ScrollView, RecyclerView) to `TeadsAdPlacementRecommendationsConfig(widgetId, urlConfig = …)`, clearing the 6.2.0 deprecation warning.

## Changes

| File | Change |
|------|--------|
| `…/v6/ui/compose/BannerDirectColumnScreen.kt` | NEW — Direct provider Banner sample |
| `…/v6/ui/compose/BannerAdmobColumnScreen.kt` | NEW — AdMob provider Banner sample |
| `…/v6/domain/FormatType.kt` | Added `BANNER("Anchored Banner")` |
| `…/v6/data/DemoSessionConfiguration.kt` | Banner Direct widget id + AdMob PIDs; extended placement/widget defaults |
| `…/v6/ui/base/navigation/Routes.kt` | Banner Direct/AdMob routes, factory, titles |
| `…/v6/ui/base/DemoViewModel.kt` | Banner providers, AdMob PID chips, Column-only filter, defaults wiring |
| `…/v6/ui/base/MainActivity.kt` | Banner top-bar titles, back nav, screen rendering |
| `…/v6/ui/base/components/FormatDescription.kt` | Banner description |
| `…/v6/ui/compose/RecommendationsColumnScreen.kt` | Migrated to `TeadsAdPlacementRecommendationsURLConfig` |
| `…/v6/ui/compose/RecommendationsLazyColumnScreen.kt` | Migrated to `TeadsAdPlacementRecommendationsURLConfig` |
| `…/v6/ui/xml/RecommendationsScrollViewFragment.kt` | Migrated to `TeadsAdPlacementRecommendationsURLConfig` |
| `…/v6/ui/xml/RecommendationsRecyclerViewFragment.kt` | Migrated to `TeadsAdPlacementRecommendationsURLConfig` (articleUrl threaded to adapter) |
| `TeadsSDKDemo/gradle.properties` | `VERSION_NAME=6.2.0`, `VERSION_CODE=144` |
| `TeadsSDKDemo/settings.gradle.kts` | Added JFrog `SDKAndroid-maven-earlyAccess` repo |

## Test Plan

- [x] `./gradlew :app:compileDebugKotlin` succeeds with SDK 6.2.0
- [ ] `./gradlew :app:assembleDebug` succeeds
- [ ] Banner Direct: Article URL / Widget ID / Installation Key fields; Column auto-selected; LAUNCH renders banner inline
- [ ] Banner AdMob: Article URL + Placement ID with "Banner" / "Google Test Banner" chips; LAUNCH renders anchored adaptive banner
- [ ] Recommendations (all 4 samples): still load and bind correctly via the new `urlConfig` path
- [ ] Logcat: `BannerDirectColumn` shows `READY` / `LOADED` / `VIEWED`; `BannerAdmobColumn` shows `onAdLoaded` / `onAdImpression`
