### PR TITLE
ART-903: AdMob banner sample — fixed AdSize.BANNER

### DIFF
--- a/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerAdmobColumnScreen.kt
+++ b/TeadsSDKDemo/app/src/main/java/tv/teads/teadssdkdemo/v6/ui/compose/BannerAdmobColumnScreen.kt
@@ -51,17 +51,12 @@ fun BannerAdmobColumnScreen(
         //    so the publisher integration is just a bare AdView)
         MobileAds.initialize(context)
 
-        // 2. Create AdMob view and configure it as an anchored adaptive banner
+        // 2. Create AdMob view and configure it with a fixed banner size
         val admobAdView = AdView(context)
         admobAdView.adUnitId = DemoSessionConfiguration.getPlacementIdOrDefault() // Your unique ad unit id
 
-        // Use anchored adaptive banner sizing — the Teads JS engine reports its
-        // own dynamic height via HEIGHT_UPDATED, so the host container view should
-        // be wrap_content to accommodate the reported size.
-        val widthDp = context.resources.configuration.screenWidthDp
-        admobAdView.setAdSize(
-            AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, widthDp)
-        )
+        // Request a fixed AdSize.BANNER (320x50dp) from the AdMob waterfall.
+        admobAdView.setAdSize(AdSize.BANNER)
 
         // 3. Listen to lifecycle events
         admobAdView.adListener = object : AdListener() {


### PR DESCRIPTION
ART-903

## Summary

Switches the AdMob anchored banner sample (`BannerAdmobColumnScreen`) from adaptive sizing to a fixed `AdSize.BANNER` (320×50dp), aligning the public sample with the SDK demo direction.

## Problem

- The sample requested `AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(...)`, which can't demonstrate fixed-size banner behavior.

## Solution

1. Request `AdSize.BANNER` on the AdMob `AdView` and drop the adaptive width computation.

## Changes

| File | Change |
|---|---|
| `TeadsSDKDemo/.../v6/ui/compose/BannerAdmobColumnScreen.kt` | `setAdSize(...adaptive...)` → `setAdSize(AdSize.BANNER)`; removed `widthDp` computation and adaptive comment |

## Test Plan

- [ ] Build & run TeadsSDKDemo, open the AdMob banner screen
- [ ] Confirm the AdView requests 320×50dp and the banner renders within the fixed slot

> Targets the draft 6.2.0 branch `feat/banner-anchored-sample` (PR #267), not master.